### PR TITLE
Add Chainlink interface

### DIFF
--- a/contracts/Chainlink.sol
+++ b/contracts/Chainlink.sol
@@ -15,15 +15,15 @@ contract Chainlink is Ownable {
     // Chainlink Aggregator Instance
     AggregatorInterface internal dataSource;
 
-    function setReferenceContract(address _aggregator) public onlyOwner {
+    function setReferenceContract(address _aggregator) external onlyOwner {
         dataSource = AggregatorInterface(_aggregator);
     }
 
-    function getLatestPrice() public view returns (int256) {
+    function getLatestPrice() external view returns (int256) {
         return dataSource.latestAnswer();
     }
 
-    function getLatestUpdateHeight() public view returns (uint256) {
+    function getLatestUpdateHeight() external view returns (uint256) {
         return dataSource.latestTimestamp();
     }
 

--- a/contracts/ZeroCollateral.sol
+++ b/contracts/ZeroCollateral.sol
@@ -19,7 +19,7 @@ pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
-import "./Chainlink.sol";
+import "./interfaces/ChainlinkInterface.sol";
 import "./ZDai.sol";
 
 /**
@@ -45,12 +45,12 @@ contract ZeroCollateralMain {
     // this contract should be given MinterRole
     ZDai public zDaiContract;
 
+    // Oracle for ETH/USD rate
+    ChainlinkInterface public oracle;
+
     // address of the Zero Collateral DAO Wallet
     // part of interest paid automatically goes back to DAO (5-10% ish)
     address public zcDaoContract;
-
-    // Oracle for ETH/USD rate
-    Chainlink public oracle;
 
     // borrow count
     uint256 public borrowCount = 0;

--- a/contracts/interfaces/ChainlinkInterface.sol
+++ b/contracts/interfaces/ChainlinkInterface.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.5.0;
+
+interface ChainlinkInterface {
+
+    function setReferenceContract(address _aggregator) external;
+    function getLatestPrice() external view returns (int256);
+    function getLatestUpdateHeight() external view returns (uint256);
+}


### PR DESCRIPTION
- Add `ChainlinkInterafce.sol`
- Import in `ZeroCollateralMain.sol` the `ChainlinkInterface` interface instead of `Chainlink` contract.

An advantage of this approach is that the `ZeroCollateralMain` contract does not have to store the bytecode of any called function from the `Chainlink.sol` contract.