### PR TITLE
Support pause (platform and lending pool level) and Settings

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -24,3 +24,12 @@ DEFAULT_ADDRESS_INDEX_KEY=0
 
 # Etherscan API key. This is used to verify smart contract in the Ethereum networks.
 ETHERSCAN_API_KEY=add-your-etherscan-api-key-here
+
+# This is the default number of node submissions for consensus.
+DEFAULT_REQUIRED_SUBMISSIONS_KEY=7
+
+# This is the maximum tolerance of difference in node submissions.
+DEFAULT_MAXIMUM_TOLERANCE_KEY=0
+
+# This is the time after which node responses expire.
+DEFAULT_RESPONSE_EXPIRY_KEY=2592000

--- a/contracts/base/Base.sol
+++ b/contracts/base/Base.sol
@@ -40,8 +40,8 @@ contract Base is Initializable, ReentrancyGuard {
         _;
     }
 
-    modifier whenLendingPoolNotPaused() {
-        require(!_isPoolPaused(address(this)), "LENDING_POOL_IS_PAUSED");
+    modifier whenLendingPoolNotPaused(address lendingPoolAddress) {
+        require(!_isPoolPaused(lendingPoolAddress), "LENDING_POOL_IS_PAUSED");
         _;
     }
 
@@ -50,8 +50,8 @@ contract Base is Initializable, ReentrancyGuard {
         _;
     }
 
-    modifier whenLendingPoolPaused() {
-        require(_isPoolPaused(address(this)), "LENDING_POOL_IS_NOT_PAUSED");
+    modifier whenLendingPoolPaused(address lendingPoolAddress) {
+        require(_isPoolPaused(lendingPoolAddress), "LENDING_POOL_IS_NOT_PAUSED");
         _;
     }
 

--- a/contracts/base/Base.sol
+++ b/contracts/base/Base.sol
@@ -1,0 +1,71 @@
+/*
+    Copyright 2020 Fabrx Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+pragma solidity 0.5.17;
+
+// Libraries
+import "openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol";
+
+// Commons
+
+// Interfaces
+import "../interfaces/SettingsInterface.sol";
+
+
+contract Base is ReentrancyGuard {
+    /* State Variables */
+
+    SettingsInterface public settings;
+
+    /** Modifiers */
+
+    modifier whenNotPaused(address lendingPoolAddress) {
+        require(
+            !_isPaused() && !_isPoolPaused(lendingPoolAddress),
+            "PLATFORM_OR_POOL_IS_PAUSED"
+        );
+        //require(, "LENDING_IS_PAUSED");
+        _;
+    }
+
+    modifier whenPaused(address lendingPoolAddress) {
+        require(
+            _isPaused() || _isPoolPaused(lendingPoolAddress),
+            "PLATFORM_OR_POOL_IS_NOT_PAUSED"
+        );
+        _;
+    }
+
+    /* Constructor */
+
+    constructor(address settingsAddress) public {
+        require(settingsAddress != address(0x0), "SETTIGNS_MUST_BE_PROVIDED");
+        settings = SettingsInterface(settingsAddress);
+    }
+
+    /** External Functions */
+
+    /** Internal functions */
+
+    function _isPoolPaused(address poolAddress) internal view returns (bool) {
+        return settings.lendingPoolPaused(poolAddress);
+    }
+
+    function _isPaused() internal view returns (bool) {
+        return settings.isPaused();
+    }
+
+    /** Private functions */
+}

--- a/contracts/base/Base.sol
+++ b/contracts/base/Base.sol
@@ -61,7 +61,7 @@ contract Base is Initializable, ReentrancyGuard {
 
     /** Internal functions */
 
-    function initialize(address settingsAddress) external isNotInitialized() {
+    function initialize(address settingsAddress) internal isNotInitialized() {
         settingsAddress.requireNotEmpty("SETTIGNS_MUST_BE_PROVIDED");
 
         initialize();

--- a/contracts/base/Base.sol
+++ b/contracts/base/Base.sol
@@ -61,7 +61,7 @@ contract Base is Initializable, ReentrancyGuard {
 
     /** Internal functions */
 
-    function initialize(address settingsAddress) internal isNotInitialized() {
+    function _initialize(address settingsAddress) internal isNotInitialized() {
         settingsAddress.requireNotEmpty("SETTINGS_MUST_BE_PROVIDED");
 
         initialize();

--- a/contracts/base/Base.sol
+++ b/contracts/base/Base.sol
@@ -62,7 +62,7 @@ contract Base is Initializable, ReentrancyGuard {
     /** Internal functions */
 
     function initialize(address settingsAddress) internal isNotInitialized() {
-        settingsAddress.requireNotEmpty("SETTIGNS_MUST_BE_PROVIDED");
+        settingsAddress.requireNotEmpty("SETTINGS_MUST_BE_PROVIDED");
 
         initialize();
 

--- a/contracts/base/Consensus.sol
+++ b/contracts/base/Consensus.sol
@@ -21,9 +21,10 @@ import "../util/ZeroCollateralCommon.sol";
 
 // Contracts
 import "openzeppelin-solidity/contracts/access/roles/SignerRole.sol";
+import "../base/Base.sol";
 
 
-contract Consensus is SignerRole {
+contract Consensus is Base, SignerRole {
     using SafeMath for uint256;
 
     // Has signer address already submitted their answer for (user, identifier)?
@@ -32,13 +33,6 @@ contract Consensus is SignerRole {
     // mapping from signer address, to signerNonce, to boolean.
     // Has the signer already used this nonce?
     mapping(address => mapping(uint256 => bool)) public signerNonceTaken;
-
-    // the total number of submissions required for consensus on a value
-    uint256 public requiredSubmissions;
-
-    // this is a percentage with 2 decimal places
-    // i.e. maximumTolerance of 325 => tolerance of 3.25% => 0.0325 of value
-    uint256 public maximumTolerance;
 
     function _signatureValid(
         ZeroCollateralCommon.Signature memory signature,

--- a/contracts/base/Initializable.sol
+++ b/contracts/base/Initializable.sol
@@ -43,6 +43,10 @@ contract Initializable {
 
     /** External Functions */
 
+    function initialized() external view returns (bool) {
+        return _isInitialized;
+    }
+
     /** Internal functions */
 
     function initialize() internal {

--- a/contracts/base/InterestConsensus.sol
+++ b/contracts/base/InterestConsensus.sol
@@ -26,18 +26,15 @@ import "../util/ZeroCollateralCommon.sol";
 import "../interfaces/InterestConsensusInterface.sol";
 
 // Contracts
-import "./Initializable.sol";
 import "./Consensus.sol";
 
 
-contract InterestConsensus is Consensus, Initializable, InterestConsensusInterface {
+contract InterestConsensus is Consensus, InterestConsensusInterface {
     using AddressLib for address;
     using SafeMath for uint256;
     using NumbersList for NumbersList.Values;
 
     address public lenders;
-
-    uint256 responseExpiryLength;
 
     // mapping of (lender, endTime) to the aggregated node submissions for their request
     mapping(address => mapping(uint256 => NumbersList.Values)) public interestSubmissions;
@@ -47,29 +44,26 @@ contract InterestConsensus is Consensus, Initializable, InterestConsensusInterfa
         _;
     }
 
-    function initialize(
-        address lendersAddress,
-        uint256 initRequiredSubmissions,
-        uint256 initMaximumTolerance,
-        uint256 initResponseExpiry
-    ) public isNotInitialized() {
+    function initialize(address lendersAddress, address settingsAddress)
+        external
+        isNotInitialized()
+    {
         lendersAddress.requireNotEmpty("MUST_PROVIDE_LENDER_INFO");
-        require(initRequiredSubmissions > 0, "MUST_PROVIDE_REQUIRED_SUBS");
-        require(initResponseExpiry > 0, "MUST_PROVIDE_RESPONSE_EXP");
+        settingsAddress.requireNotEmpty("MUST_PROVIDE_SETTINGS");
 
-        initialize();
+        initialize(settingsAddress);
 
         lenders = lendersAddress;
-        requiredSubmissions = initRequiredSubmissions;
-        maximumTolerance = initMaximumTolerance;
-        responseExpiryLength = initResponseExpiry;
     }
 
     function processRequest(
         ZeroCollateralCommon.InterestRequest calldata request,
         ZeroCollateralCommon.InterestResponse[] calldata responses
     ) external isInitialized() isLenders() returns (uint256) {
-        require(responses.length >= requiredSubmissions, "INSUFFICIENT_RESPONSES");
+        require(
+            responses.length >= settings.requiredSubmissions(),
+            "INSUFFICIENT_RESPONSES"
+        );
 
         bytes32 requestHash = _hashRequest(request);
 
@@ -79,7 +73,7 @@ contract InterestConsensus is Consensus, Initializable, InterestConsensusInterfa
 
         require(
             interestSubmissions[request.lender][request.endTime].isWithinTolerance(
-                maximumTolerance
+                settings.maximumTolerance()
             ),
             "RESPONSES_TOO_VARIED"
         );
@@ -110,7 +104,7 @@ contract InterestConsensus is Consensus, Initializable, InterestConsensusInterfa
         signerNonceTaken[response.signer][response.signature.signerNonce] = true;
 
         require(
-            response.responseTime >= now.sub(responseExpiryLength),
+            response.responseTime >= now.sub(settings.responseExpiryLength()),
             "RESPONSE_EXPIRED"
         );
 

--- a/contracts/base/InterestConsensus.sol
+++ b/contracts/base/InterestConsensus.sol
@@ -51,7 +51,7 @@ contract InterestConsensus is Consensus, InterestConsensusInterface {
         lendersAddress.requireNotEmpty("MUST_PROVIDE_LENDER_INFO");
         settingsAddress.requireNotEmpty("MUST_PROVIDE_SETTINGS");
 
-        initialize(settingsAddress);
+        _initialize(settingsAddress);
 
         lenders = lendersAddress;
     }

--- a/contracts/base/Lenders.sol
+++ b/contracts/base/Lenders.sol
@@ -35,17 +35,14 @@ contract Lenders is LendersInterface {
     address public lendingPool;
     InterestConsensusInterface public interestConsensus;
 
-    ZTokenInterface public zToken;
+    address public zToken;
 
     // The total interest that has not yet been withdrawn by a lender
     mapping(address => ZeroCollateralCommon.AccruedInterest) public accruedInterest;
 
     /** Modifiers */
     modifier isZToken() {
-        require(
-            _areAddressesEqual(address(zToken), msg.sender),
-            "Address has no permissions."
-        );
+        require(_areAddressesEqual(zToken, msg.sender), "Address has no permissions.");
         _;
     }
 
@@ -75,7 +72,7 @@ contract Lenders is LendersInterface {
             interestConsensusAddress != address(0x0),
             "Consensus address is required."
         );
-        zToken = ZTokenInterface(zTokenAddress);
+        zToken = zTokenAddress;
         lendingPool = lendingPoolAddress;
         interestConsensus = InterestConsensusInterface(interestConsensusAddress);
     }
@@ -150,12 +147,4 @@ contract Lenders is LendersInterface {
     }
 
     /** Private Functions */
-
-    function _getZTokenBalanceOf(address anAddress) private view returns (uint256) {
-        return zToken.balanceOf(anAddress);
-    }
-
-    function _getCurrentBlockNumber() private view returns (uint256) {
-        return block.number;
-    }
 }

--- a/contracts/base/Lenders.sol
+++ b/contracts/base/Lenders.sol
@@ -76,7 +76,7 @@ contract Lenders is Base, LendersInterface {
         lendingPoolAddress.requireNotEmpty("LENDING_POOL_MUST_BE_PROVIDED");
         interestConsensusAddress.requireNotEmpty("CONSENSUS_MUST_BE_PROVIDED");
 
-        initialize(settingAddress);
+        _initialize(settingAddress);
 
         zToken = zTokenAddress;
         lendingPool = lendingPoolAddress;
@@ -86,7 +86,7 @@ contract Lenders is Base, LendersInterface {
     function setAccruedInterest(
         ZeroCollateralCommon.InterestRequest calldata request,
         ZeroCollateralCommon.InterestResponse[] calldata responses
-    ) external isInitialized() whenNotPaused() whenLendingPoolNotPaused() nonReentrant() {
+    ) external isInitialized() whenNotPaused() whenLendingPoolNotPaused() {
         require(
             accruedInterest[request.lender].timeLastAccrued == request.startTime,
             "GAP_IN_INTEREST_ACCRUAL"
@@ -120,9 +120,6 @@ contract Lenders is Base, LendersInterface {
         isLendingPool()
         isValid(recipient)
         isInitialized()
-        whenNotPaused()
-        whenLendingPoolNotPaused()
-        nonReentrant()
         returns (uint256)
     {
         uint256 amountToWithdraw = amount;

--- a/contracts/base/Lenders.sol
+++ b/contracts/base/Lenders.sol
@@ -86,7 +86,7 @@ contract Lenders is Base, LendersInterface {
     function setAccruedInterest(
         ZeroCollateralCommon.InterestRequest calldata request,
         ZeroCollateralCommon.InterestResponse[] calldata responses
-    ) external isInitialized() whenNotPaused() whenLendingPoolNotPaused() {
+    ) external isInitialized() whenNotPaused() whenLendingPoolNotPaused(lendingPool) {
         require(
             accruedInterest[request.lender].timeLastAccrued == request.startTime,
             "GAP_IN_INTEREST_ACCRUAL"

--- a/contracts/base/Lenders.sol
+++ b/contracts/base/Lenders.sol
@@ -120,6 +120,7 @@ contract Lenders is Base, LendersInterface {
         isLendingPool()
         isValid(recipient)
         isInitialized()
+
         returns (uint256)
     {
         uint256 amountToWithdraw = amount;

--- a/contracts/base/LendingPool.sol
+++ b/contracts/base/LendingPool.sol
@@ -99,7 +99,7 @@ contract LendingPool is Base, LendingPoolInterface {
         external
         isInitialized()
         whenNotPaused()
-        whenLendingPoolNotPaused()
+        whenLendingPoolNotPaused(address(this))
     {
         // Transfering tokens to the LendingPool
         tokenTransferFrom(msg.sender, amount);
@@ -119,7 +119,7 @@ contract LendingPool is Base, LendingPoolInterface {
         external
         isInitialized()
         whenNotPaused()
-        whenLendingPoolNotPaused()
+        whenLendingPoolNotPaused(address(this))
         nonReentrant()
     {
         // Burn zToken tokens.
@@ -144,7 +144,7 @@ contract LendingPool is Base, LendingPoolInterface {
         external
         isInitialized()
         isLoan()
-        whenLendingPoolNotPaused()
+        whenLendingPoolNotPaused(address(this))
     {
         // Transfers tokens to LendingPool.
         tokenTransferFrom(borrower, amount);
@@ -162,7 +162,7 @@ contract LendingPool is Base, LendingPoolInterface {
         external
         isInitialized()
         isLoan()
-        whenLendingPoolNotPaused()
+        whenLendingPoolNotPaused(address(this))
     {
         // Transfers tokens to the liquidator.
         tokenTransfer(liquidator, amount);
@@ -182,7 +182,7 @@ contract LendingPool is Base, LendingPoolInterface {
         external
         isInitialized()
         isLoan()
-        whenLendingPoolNotPaused()
+        whenLendingPoolNotPaused(address(this))
     {
         // Transfer tokens to the borrower.
         tokenTransfer(borrower, amount);
@@ -192,7 +192,7 @@ contract LendingPool is Base, LendingPoolInterface {
         external
         isInitialized()
         whenNotPaused()
-        whenLendingPoolNotPaused()
+        whenLendingPoolNotPaused(address(this))
     {
         address lender = msg.sender;
 

--- a/contracts/base/LendingPool.sol
+++ b/contracts/base/LendingPool.sol
@@ -201,7 +201,17 @@ contract LendingPool is Base, LendingPoolInterface {
         whenNotPaused()
         whenLendingPoolNotPaused()
         nonReentrant()
-    {}
+    {
+        address lender = msg.sender;
+
+        uint256 amountWithdrawn = lenders.withdrawInterest(lender, amount);
+
+        requireEnoughLendingTokenBalance(amountWithdrawn);
+
+        tokenTransfer(lender, amountWithdrawn);
+
+        emit InterestWithdrawn(lender, amountWithdrawn);
+    }
 
     /** Internal functions */
 
@@ -227,6 +237,11 @@ contract LendingPool is Base, LendingPoolInterface {
     function tokenTransferFrom(address from, uint256 amount) private {
         bool transferFromResult = lendingToken.transferFrom(from, address(this), amount);
         require(transferFromResult, "TransferFrom wasn't successful.");
+    }
+
+    function requireEnoughLendingTokenBalance(uint256 amount) private view {
+        uint256 lendingTokenBalance = lendingToken.balanceOf(address(this));
+        require(lendingTokenBalance >= amount, "NOT_ENOUGH_LENDING_TOKEN_BALANCE");
     }
 
     /**

--- a/contracts/base/LendingPool.sol
+++ b/contracts/base/LendingPool.sol
@@ -82,7 +82,7 @@ contract LendingPool is Base, LendingPoolInterface {
         lendersAddress.requireNotEmpty("Lenders address is required.");
         loansAddress.requireNotEmpty("Loans address is required.");
 
-        this.initialize(settingsAddress);
+        initialize(settingsAddress);
 
         zToken = ZTokenInterface(zTokenAddress);
         lendingToken = IERC20(lendingTokenAddress);

--- a/contracts/base/LendingPool.sol
+++ b/contracts/base/LendingPool.sol
@@ -33,10 +33,7 @@ import "./Base.sol";
 /**
     @notice The LendingPool contract holds all of the tokens that lenders transfer into the protocol. It is the contract that lenders interact with to deposit and withdraw their tokens including interest. The LendingPool interacts with the Lenders contract to ensure token balances and interest owed is kept up to date.
  */
-contract LendingPool is
-    Base,
-    LendingPoolInterface
-{
+contract LendingPool is Base, LendingPoolInterface {
     using AddressLib for address;
 
     /* State Variables */

--- a/contracts/base/LendingPool.sol
+++ b/contracts/base/LendingPool.sol
@@ -82,7 +82,7 @@ contract LendingPool is Base, LendingPoolInterface {
         lendersAddress.requireNotEmpty("Lenders address is required.");
         loansAddress.requireNotEmpty("Loans address is required.");
 
-        initialize(settingsAddress);
+        _initialize(settingsAddress);
 
         zToken = ZTokenInterface(zTokenAddress);
         lendingToken = IERC20(lendingTokenAddress);
@@ -100,7 +100,6 @@ contract LendingPool is Base, LendingPoolInterface {
         isInitialized()
         whenNotPaused()
         whenLendingPoolNotPaused()
-        nonReentrant()
     {
         // Transfering tokens to the LendingPool
         tokenTransferFrom(msg.sender, amount);
@@ -145,9 +144,7 @@ contract LendingPool is Base, LendingPoolInterface {
         external
         isInitialized()
         isLoan()
-        whenNotPaused()
         whenLendingPoolNotPaused()
-        nonReentrant()
     {
         // Transfers tokens to LendingPool.
         tokenTransferFrom(borrower, amount);
@@ -165,9 +162,7 @@ contract LendingPool is Base, LendingPoolInterface {
         external
         isInitialized()
         isLoan()
-        whenNotPaused()
         whenLendingPoolNotPaused()
-        nonReentrant()
     {
         // Transfers tokens to the liquidator.
         tokenTransfer(liquidator, amount);
@@ -187,9 +182,7 @@ contract LendingPool is Base, LendingPoolInterface {
         external
         isInitialized()
         isLoan()
-        whenNotPaused()
         whenLendingPoolNotPaused()
-        nonReentrant()
     {
         // Transfer tokens to the borrower.
         tokenTransfer(borrower, amount);
@@ -200,7 +193,6 @@ contract LendingPool is Base, LendingPoolInterface {
         isInitialized()
         whenNotPaused()
         whenLendingPoolNotPaused()
-        nonReentrant()
     {
         address lender = msg.sender;
 

--- a/contracts/base/Loans.sol
+++ b/contracts/base/Loans.sol
@@ -66,7 +66,7 @@ contract Loans is Base, LoansInterface, SignerRole {
         require(priceOracleAddress != address(0), "PROVIDE_ORACLE_ADDRESS");
         require(lendingPoolAddress != address(0), "PROVIDE_LENDINGPOOL_ADDRESS");
 
-        initialize(settingsAddress);
+        _initialize(settingsAddress);
 
         priceOracle = PairAggregatorInterface(priceOracleAddress);
         lendingPool = LendingPoolInterface(lendingPoolAddress);
@@ -84,7 +84,6 @@ contract Loans is Base, LoansInterface, SignerRole {
         isInitialized()
         whenNotPaused()
         whenLendingPoolNotPaused()
-        nonReentrant()
     {
         require(loans[loanID].borrower == borrower, "BORROWER_LOAN_ID_MISMATCH");
         require(loans[loanID].active, "LOAN_NOT_ACTIVE");

--- a/contracts/base/Loans.sol
+++ b/contracts/base/Loans.sol
@@ -83,7 +83,7 @@ contract Loans is Base, LoansInterface, SignerRole {
         loanIDValid(loanID)
         isInitialized()
         whenNotPaused()
-        whenLendingPoolNotPaused()
+        whenLendingPoolNotPaused(address(lendingPool))
     {
         require(loans[loanID].borrower == borrower, "BORROWER_LOAN_ID_MISMATCH");
         require(loans[loanID].active, "LOAN_NOT_ACTIVE");
@@ -106,7 +106,7 @@ contract Loans is Base, LoansInterface, SignerRole {
         loanIDValid(loanID)
         isInitialized()
         whenNotPaused()
-        whenLendingPoolNotPaused()
+        whenLendingPoolNotPaused(address(lendingPool))
         nonReentrant()
     {
         require(msg.sender == loans[loanID].borrower, "CALLER_DOESNT_OWN_LOAN");
@@ -161,7 +161,7 @@ contract Loans is Base, LoansInterface, SignerRole {
         payable
         isInitialized()
         whenNotPaused()
-        whenLendingPoolNotPaused()
+        whenLendingPoolNotPaused(address(lendingPool))
         nonReentrant()
         returns (uint256)
     {
@@ -249,7 +249,7 @@ contract Loans is Base, LoansInterface, SignerRole {
         loanIDValid(loanID)
         isInitialized()
         whenNotPaused()
-        whenLendingPoolNotPaused()
+        whenLendingPoolNotPaused(address(lendingPool))
         nonReentrant()
     {
         require(loans[loanID].active, "LOAN_NOT_ACTIVE");
@@ -286,7 +286,7 @@ contract Loans is Base, LoansInterface, SignerRole {
         loanIDValid(loanID)
         isInitialized()
         whenNotPaused()
-        whenLendingPoolNotPaused()
+        whenLendingPoolNotPaused(address(lendingPool))
         nonReentrant()
     {
         require(loans[loanID].active, "LOAN_NOT_ACTIVE");

--- a/contracts/base/Loans.sol
+++ b/contracts/base/Loans.sol
@@ -17,6 +17,7 @@
 pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
+import "../base/Base.sol";
 import "../interfaces/LoansInterface.sol";
 import "../interfaces/PairAggregatorInterface.sol";
 import "../interfaces/LendingPoolInterface.sol";
@@ -26,7 +27,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
 import "openzeppelin-solidity/contracts/access/roles/SignerRole.sol";
 
 
-contract Loans is LoansInterface, SignerRole {
+contract Loans is Base, LoansInterface, SignerRole {
     using SafeMath for uint256;
 
     uint256 private constant ONE_HOUR = 3600;
@@ -57,9 +58,15 @@ contract Loans is LoansInterface, SignerRole {
         _;
     }
 
-    constructor(address priceOracleAddress, address lendingPoolAddress) public {
+    function initialize(
+        address priceOracleAddress,
+        address lendingPoolAddress,
+        address settingsAddress
+    ) external isNotInitialized() {
         require(priceOracleAddress != address(0), "PROVIDE_ORACLE_ADDRESS");
         require(lendingPoolAddress != address(0), "PROVIDE_LENDINGPOOL_ADDRESS");
+
+        initialize(settingsAddress);
 
         priceOracle = PairAggregatorInterface(priceOracleAddress);
         lendingPool = LendingPoolInterface(lendingPoolAddress);
@@ -74,6 +81,10 @@ contract Loans is LoansInterface, SignerRole {
         external
         payable
         loanIDValid(loanID)
+        isInitialized()
+        whenNotPaused()
+        whenLendingPoolNotPaused()
+        nonReentrant()
     {
         require(loans[loanID].borrower == borrower, "BORROWER_LOAN_ID_MISMATCH");
         require(loans[loanID].active, "LOAN_NOT_ACTIVE");
@@ -94,6 +105,10 @@ contract Loans is LoansInterface, SignerRole {
     function withdrawCollateral(uint256 amount, uint256 loanID)
         external
         loanIDValid(loanID)
+        isInitialized()
+        whenNotPaused()
+        whenLendingPoolNotPaused()
+        nonReentrant()
     {
         require(msg.sender == loans[loanID].borrower, "CALLER_DOESNT_OWN_LOAN");
 
@@ -142,7 +157,15 @@ contract Loans is LoansInterface, SignerRole {
         uint256 numberDays,
         uint256 amountBorrow,
         ZeroCollateralCommon.Signature calldata signature
-    ) external payable returns (uint256) {
+    )
+        external
+        payable
+        isInitialized()
+        whenNotPaused()
+        whenLendingPoolNotPaused()
+        nonReentrant()
+        returns (uint256)
+    {
         require(amountBorrow <= maxLoanAmount, "BORROW_AMOUNT_NOT_AUTHORIZED");
 
         address signer = ecrecover(
@@ -222,7 +245,14 @@ contract Loans is LoansInterface, SignerRole {
      * @param amount uint256 The amount of tokens to pay back to the loan
      * @param loanID uint256 The ID of the loan the payment is for
      */
-    function repay(uint256 amount, uint256 loanID) external loanIDValid(loanID) {
+    function repay(uint256 amount, uint256 loanID)
+        external
+        loanIDValid(loanID)
+        isInitialized()
+        whenNotPaused()
+        whenLendingPoolNotPaused()
+        nonReentrant()
+    {
         require(loans[loanID].active, "LOAN_NOT_ACTIVE");
 
         // calculate the actual amount to repay
@@ -252,7 +282,14 @@ contract Loans is LoansInterface, SignerRole {
      * @notice Liquidate a loan if it is expired or undercollateralised
      * @param loanID uint256 The ID of the loan to be liquidated
      */
-    function liquidateLoan(uint256 loanID) external loanIDValid(loanID) {
+    function liquidateLoan(uint256 loanID)
+        external
+        loanIDValid(loanID)
+        isInitialized()
+        whenNotPaused()
+        whenLendingPoolNotPaused()
+        nonReentrant()
+    {
         require(loans[loanID].active, "LOAN_NOT_ACTIVE");
 
         // check that enough collateral has been provided for this loan

--- a/contracts/base/Settings.sol
+++ b/contracts/base/Settings.sol
@@ -17,7 +17,6 @@ pragma solidity 0.5.17;
 
 // Libraries
 import "openzeppelin-solidity/contracts/lifecycle/Pausable.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 // Commons
 import "../util/AddressLib.sol";
@@ -27,7 +26,7 @@ import "../util/AddressLib.sol";
 import "../interfaces/SettingsInterface.sol";
 
 
-contract Settings is Pausable, Ownable, SettingsInterface {
+contract Settings is Pausable, SettingsInterface {
     using AddressLib for address;
 
     /** Constants */
@@ -68,7 +67,7 @@ contract Settings is Pausable, Ownable, SettingsInterface {
 
     function setRequiredSubmissions(uint256 newRequiredSubmissions)
         external
-        onlyOwner()
+        onlyPauser()
         whenNotPaused()
     {
         require(requiredSubmissions != newRequiredSubmissions, "NEW_VALUE_REQUIRED");
@@ -86,7 +85,7 @@ contract Settings is Pausable, Ownable, SettingsInterface {
 
     function setMaximumTolerance(uint256 newMaximumTolerance)
         external
-        onlyOwner()
+        onlyPauser()
         whenNotPaused()
     {
         require(maximumTolerance != newMaximumTolerance, "NEW_VALUE_REQUIRED");
@@ -103,7 +102,7 @@ contract Settings is Pausable, Ownable, SettingsInterface {
 
     function setResponseExpiryLength(uint256 newResponseExpiryLength)
         external
-        onlyOwner()
+        onlyPauser()
         whenNotPaused()
     {
         require(responseExpiryLength != newResponseExpiryLength, "NEW_VALUE_REQUIRED");
@@ -121,7 +120,7 @@ contract Settings is Pausable, Ownable, SettingsInterface {
 
     function pauseLendingPool(address lendingPoolAddress)
         external
-        onlyOwner()
+        onlyPauser()
         whenNotPaused()
     {
         lendingPoolAddress.requireNotEmpty("LENDING_POOL_IS_REQUIRED");
@@ -134,7 +133,7 @@ contract Settings is Pausable, Ownable, SettingsInterface {
 
     function unpauseLendingPool(address lendingPoolAddress)
         external
-        onlyOwner()
+        onlyPauser()
         whenNotPaused()
     {
         lendingPoolAddress.requireNotEmpty("LENDING_POOL_IS_REQUIRED");

--- a/contracts/base/Settings.sol
+++ b/contracts/base/Settings.sol
@@ -1,0 +1,120 @@
+/*
+    Copyright 2020 Fabrx Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+pragma solidity 0.5.17;
+
+// Libraries
+import "openzeppelin-solidity/contracts/lifecycle/Pausable.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
+// Commons
+import "../util/AddressLib.sol";
+
+// Interfaces
+
+import "../interfaces/SettingsInterface.sol";
+
+
+contract Settings is Pausable, Ownable, SettingsInterface {
+    using AddressLib for address;
+
+    /* State Variables */
+
+    mapping(address => bool) public lendingPoolPaused;
+
+    uint256 public requiredSubmissions;
+
+    uint256 public maximumTolerance;
+
+    /** Modifiers */
+
+    /* Constructor */
+
+    constructor(uint256 aRequiredSubmissions, uint256 aMaximumTolerance)
+        public
+        Pausable()
+    {
+        requiredSubmissions = aRequiredSubmissions;
+        maximumTolerance = aMaximumTolerance;
+    }
+
+    /** External Functions */
+
+    function setRequiredSubmissions(uint256 newRequiredSubmissions)
+        external
+        onlyOwner()
+        whenNotPaused()
+    {
+        require(requiredSubmissions != newRequiredSubmissions, "NEW_VALUE_REQUIRED");
+        uint256 oldRequiredSubmissions = requiredSubmissions;
+        requiredSubmissions = newRequiredSubmissions;
+
+        emit RequiredSubmissionsUpdated(
+            msg.sender,
+            oldRequiredSubmissions,
+            newRequiredSubmissions
+        );
+    }
+
+    function setMaximumTolerance(uint256 newMaximumTolerance)
+        external
+        onlyOwner()
+        whenNotPaused()
+    {
+        require(maximumTolerance != newMaximumTolerance, "NEW_VALUE_REQUIRED");
+        uint256 oldMaximumTolerance = maximumTolerance;
+        maximumTolerance = newMaximumTolerance;
+
+        emit MaximumToleranceUpdated(
+            msg.sender,
+            oldMaximumTolerance,
+            newMaximumTolerance
+        );
+    }
+
+    function pauseLendingPool(address lendingPoolAddress)
+        external
+        onlyOwner()
+        whenNotPaused()
+    {
+        lendingPoolAddress.requireNotEmpty("LENDING_POOL_IS_REQUIRED");
+        require(!lendingPoolPaused[lendingPoolAddress], "LENDING_POOL_ALREADY_PAUSED");
+
+        lendingPoolPaused[lendingPoolAddress] = true;
+
+        emit LendingPoolPaused(msg.sender, lendingPoolAddress);
+    }
+
+    function unpauseLendingPool(address lendingPoolAddress)
+        external
+        onlyOwner()
+        whenNotPaused()
+    {
+        lendingPoolAddress.requireNotEmpty("LENDING_POOL_IS_REQUIRED");
+        require(lendingPoolPaused[lendingPoolAddress], "LENDING_POOL_IS_NOT_PAUSED");
+
+        lendingPoolPaused[lendingPoolAddress] = false;
+
+        emit LendingPoolUnpaused(msg.sender, lendingPoolAddress);
+    }
+
+    function isPaused() external view returns (bool) {
+        return paused();
+    }
+
+    /** Internal functions */
+
+    /** Private functions */
+}

--- a/contracts/base/Settings.sol
+++ b/contracts/base/Settings.sol
@@ -42,10 +42,7 @@ contract Settings is Pausable, Ownable, SettingsInterface {
 
     /* Constructor */
 
-    constructor(uint256 aRequiredSubmissions, uint256 aMaximumTolerance)
-        public
-        Pausable()
-    {
+    constructor(uint256 aRequiredSubmissions, uint256 aMaximumTolerance) public {
         requiredSubmissions = aRequiredSubmissions;
         maximumTolerance = aMaximumTolerance;
     }

--- a/contracts/interfaces/LendingPoolInterface.sol
+++ b/contracts/interfaces/LendingPoolInterface.sol
@@ -73,6 +73,13 @@ interface LendingPoolInterface {
     event TokenRepaid(address indexed borrower, uint256 amount);
 
     /**
+        @notice This event is emitted when an lender withdraws interests.
+        @param lender address.
+        @param amount of tokens.
+     */
+    event InterestWithdrawn(address indexed lender, uint256 amount);
+
+    /**
         @notice This event is emitted when a liquidator liquidates a loan.
         @param liquidator address.
         @param amount of tokens.

--- a/contracts/interfaces/SettingsInterface.sol
+++ b/contracts/interfaces/SettingsInterface.sol
@@ -2,16 +2,11 @@ pragma solidity 0.5.17;
 
 
 interface SettingsInterface {
-    event RequiredSubmissionsUpdated(
+    event SettingUpdated(
+        bytes32 indexed settingName,
         address indexed sender,
-        uint256 oldRequiredSubmissions,
-        uint256 newRequiredSubmissions
-    );
-
-    event MaximumToleranceUpdated(
-        address indexed sender,
-        uint256 oldMaximumTolerance,
-        uint256 newMaximumTolerance
+        uint256 oldValue,
+        uint256 newValue
     );
 
     event LendingPoolPaused(address indexed account, address indexed lendingPoolAddress);
@@ -28,6 +23,10 @@ interface SettingsInterface {
     function maximumTolerance() external view returns (uint256);
 
     function setMaximumTolerance(uint256 newMaximumTolerance) external;
+
+    function responseExpiryLength() external view returns (uint256);
+
+    function setResponseExpiryLength(uint256 newResponseExpiryLength) external;
 
     function isPaused() external view returns (bool);
 

--- a/contracts/interfaces/SettingsInterface.sol
+++ b/contracts/interfaces/SettingsInterface.sol
@@ -1,0 +1,39 @@
+pragma solidity 0.5.17;
+
+
+interface SettingsInterface {
+    event RequiredSubmissionsUpdated(
+        address indexed sender,
+        uint256 oldRequiredSubmissions,
+        uint256 newRequiredSubmissions
+    );
+
+    event MaximumToleranceUpdated(
+        address indexed sender,
+        uint256 oldMaximumTolerance,
+        uint256 newMaximumTolerance
+    );
+
+    event LendingPoolPaused(address indexed account, address indexed lendingPoolAddress);
+
+    event LendingPoolUnpaused(
+        address indexed account,
+        address indexed lendingPoolAddress
+    );
+
+    function requiredSubmissions() external view returns (uint256);
+
+    function setRequiredSubmissions(uint256 newRequiredSubmissions) external;
+
+    function maximumTolerance() external view returns (uint256);
+
+    function setMaximumTolerance(uint256 newMaximumTolerance) external;
+
+    function isPaused() external view returns (bool);
+
+    function lendingPoolPaused(address lendingPoolAddress) external view returns (bool);
+
+    function pauseLendingPool(address lendingPoolAddress) external;
+
+    function unpauseLendingPool(address lendingPoolAddress) external;
+}

--- a/contracts/mock/base/BaseMock.sol
+++ b/contracts/mock/base/BaseMock.sol
@@ -4,15 +4,11 @@ import "../../base/Base.sol";
 
 contract BaseMock is Base {
 
-    constructor(address settingsAddress)
-        public
-        Base(settingsAddress) { }
+    function externalWhenNotPaused() external whenNotPaused() {}
 
-    function externalWhenNotPaused() external whenNotPaused(address(this)) {}
+    function externalWhenLendingPoolNotPaused() external whenLendingPoolNotPaused() {}
 
-    function externalWhenNotPausedAn(address anAddress) external whenNotPaused(anAddress) {}
+    function externalWhenPaused() external whenPaused() {}
 
-    function externalWhenPaused() external whenPaused(address(this)) {}
-
-    function externalWhenPausedAn(address anAddress) external whenPaused(anAddress) {}
+    function externalWhenLendingPoolPaused() external whenLendingPoolPaused() {}
 }

--- a/contracts/mock/base/BaseMock.sol
+++ b/contracts/mock/base/BaseMock.sol
@@ -11,4 +11,8 @@ contract BaseMock is Base {
     function externalWhenPaused() external whenPaused() {}
 
     function externalWhenLendingPoolPaused() external whenLendingPoolPaused() {}
+
+    function externalInitialize(address settingsAddress) external {
+        super.initialize(settingsAddress);
+    }
 }

--- a/contracts/mock/base/BaseMock.sol
+++ b/contracts/mock/base/BaseMock.sol
@@ -13,6 +13,6 @@ contract BaseMock is Base {
     function externalWhenLendingPoolPaused() external whenLendingPoolPaused() {}
 
     function externalInitialize(address settingsAddress) external {
-        super.initialize(settingsAddress);
+        super._initialize(settingsAddress);
     }
 }

--- a/contracts/mock/base/BaseMock.sol
+++ b/contracts/mock/base/BaseMock.sol
@@ -6,11 +6,11 @@ contract BaseMock is Base {
 
     function externalWhenNotPaused() external whenNotPaused() {}
 
-    function externalWhenLendingPoolNotPaused() external whenLendingPoolNotPaused() {}
+    function externalWhenLendingPoolNotPaused(address lendingPoolAddress) external whenLendingPoolNotPaused(lendingPoolAddress) {}
 
     function externalWhenPaused() external whenPaused() {}
 
-    function externalWhenLendingPoolPaused() external whenLendingPoolPaused() {}
+    function externalWhenLendingPoolPaused(address lendingPoolAddress) external whenLendingPoolPaused(lendingPoolAddress) {}
 
     function externalInitialize(address settingsAddress) external {
         super._initialize(settingsAddress);

--- a/contracts/mock/base/BaseMock.sol
+++ b/contracts/mock/base/BaseMock.sol
@@ -1,0 +1,18 @@
+pragma solidity 0.5.17;
+
+import "../../base/Base.sol";
+
+contract BaseMock is Base {
+
+    constructor(address settingsAddress)
+        public
+        Base(settingsAddress) { }
+
+    function externalWhenNotPaused() external whenNotPaused(address(this)) {}
+
+    function externalWhenNotPausedAn(address anAddress) external whenNotPaused(anAddress) {}
+
+    function externalWhenPaused() external whenPaused(address(this)) {}
+
+    function externalWhenPausedAn(address anAddress) external whenPaused(anAddress) {}
+}

--- a/contracts/mock/base/LendersMock.sol
+++ b/contracts/mock/base/LendersMock.sol
@@ -25,27 +25,11 @@ contract LendersMock is Lenders {
     
     /** State Variables */
 
-    bool public addressesEqual;
+    bool public addressesEqual = true;
 
     /** Constructor */
-    constructor(
-        address zTokenAddress,
-        address lendingPoolAddress,
-        address consensusAddress
-    )
-        public
-        Lenders(zTokenAddress, lendingPoolAddress, consensusAddress)
-    {
-        addressesEqual = true;
-    }
 
-    function _areAddressesEqual(address, address)
-        internal
-        view
-        returns (bool)
-    {
-        return addressesEqual;
-    }
+    /** External Functions */
 
     function mockLenderInfo(
         address lender,
@@ -58,4 +42,13 @@ contract LendersMock is Lenders {
         accruedInterest[lender].totalNotWithdrawn = totalNotWithdrawn;
     }
 
+    /** Internal Functions */
+
+    function _areAddressesEqual(address, address)
+        internal
+        view
+        returns (bool)
+    {
+        return addressesEqual;
+    }
 }

--- a/contracts/mock/base/LendersModifiersMock.sol
+++ b/contracts/mock/base/LendersModifiersMock.sol
@@ -25,15 +25,9 @@ contract LendersModifiersMock is Lenders {
     
     /** State Variables */
 
-    /** Connstructor */
-    constructor(
-        address zTokenAddress,
-        address lendingPoolAddress,
-        address consensusAddress
-    )
-        public
-        Lenders(zTokenAddress, lendingPoolAddress, consensusAddress)
-    {}
+    /** Constructor */
+
+    /** External Functions */
 
     function externalIsZToken() isZToken() external {}
 

--- a/contracts/mock/base/LoansMock.sol
+++ b/contracts/mock/base/LoansMock.sol
@@ -7,9 +7,6 @@ import "../../base/Loans.sol";
 
 contract LoansMock is Loans {
 
-    constructor(address priceOracleAddress, address lendingPoolAddress)
-        public
-        Loans(priceOracleAddress, lendingPoolAddress) { }
 
     function setLoanIDCounter(uint256 newLoanIdCounter)
         external

--- a/contracts/mock/util/AddressLibMock.sol
+++ b/contracts/mock/util/AddressLibMock.sol
@@ -1,0 +1,50 @@
+pragma solidity 0.5.17;
+
+import "../../util/AddressLib.sol";
+
+contract AddressLibMock {
+    using AddressLib for address;
+
+    string public constant REQUIRE_NOT_EMPTY_ERROR_MESSAGE = "ADDRESS_MUST_BE_PROVIDED";
+    string public constant REQUIRE_EMPTY_ERROR_MESSAGE = "ADDRESS_MUST_BE_EMPTY";
+    string public constant REQUIRE_EQUAL_TO_ERROR_MESSAGE = "ADDRESSES_MUST_BE_EQUAL";
+    string public constant REQUIRE_NOT_EQUAL_TO_ERROR_MESSAGE = "ADDRESSES_MUST_NOT_BE_EQUAL";
+
+    function isEmpty(address self) external pure returns (bool) {
+        return self.isEmpty();
+    }
+
+    function isEqualTo(address left, address right) external pure returns (bool) {
+        return left.isEqualTo(right);
+    }
+
+    function isNotEqualTo(address left, address right) external pure returns (bool) {
+        return left.isNotEqualTo(right);
+    }
+
+    function isNotEmpty(address self) external pure returns (bool) {
+        return self.isNotEmpty();
+    }
+
+    function requireNotEmpty(address self) external pure {
+        self.requireNotEmpty(REQUIRE_NOT_EMPTY_ERROR_MESSAGE);
+    }
+
+    function requireEmpty(address self) external pure {
+        self.requireEmpty(REQUIRE_EMPTY_ERROR_MESSAGE);
+    }
+
+    function requireEqualTo(address left, address right)
+        external
+        pure
+    {
+        left.requireEqualTo(right, REQUIRE_EQUAL_TO_ERROR_MESSAGE);
+    }
+
+    function requireNotEqualTo(address left, address right)
+        external
+        pure
+    {
+        left.requireNotEqualTo(right, REQUIRE_NOT_EQUAL_TO_ERROR_MESSAGE);
+    }
+}

--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -7,6 +7,7 @@ const PoolDeployer = require('./utils/PoolDeployer');
 // Official Smart Contracts
 const ZDAI = artifacts.require("./base/ZDAI.sol");
 const ZUSDC = artifacts.require("./base/ZUSDC.sol");
+const Settings = artifacts.require("./base/Settings.sol");
 const Lenders = artifacts.require("./base/Lenders.sol");
 const Loans = artifacts.require("./base/Loans.sol");
 const LendingPool = artifacts.require("./base/LendingPool.sol");
@@ -43,17 +44,19 @@ module.exports = async function(deployer, network, accounts) {
   };
 
   // Creating DeployerApp helper.
+  const deployerApp = new DeployerApp(deployer, web3, deployerAccount, network);
+  
+  await deployerApp.deploys([ZDAI, ZUSDC], txConfig);
+  await deployerApp.deploy(Settings, requiredSubmissions, maximumTolerance, txConfig);
   const artifacts = {
     Lenders,
     Loans,
     LendingPool,
     InterestConsensus,
-    ChainlinkPairAggregator
+    ChainlinkPairAggregator,
+    Settings,
   };
-  const deployerApp = new DeployerApp(deployer, web3, deployerAccount, network);
   const poolDeployer = new PoolDeployer(deployerApp, deployConfig, artifacts);
-
-  await deployerApp.deploys([ZDAI, ZUSDC], txConfig);
 
   await poolDeployer.deployPool('DAI_ETH', 'DAI', ZDAI, txConfig);
   await poolDeployer.deployPool('USDC_ETH', 'USDC', ZUSDC, txConfig);

--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -36,9 +36,6 @@ module.exports = async function(deployer, network, accounts) {
 
   const txConfig = { gas: maxGasLimit, from: deployerAccount };
   const deployConfig = {
-    requiredSubmissions,
-    maximumTolerance,
-    responseExpiry,
     tokens,
     aggregators: chainlink,
   };
@@ -47,7 +44,7 @@ module.exports = async function(deployer, network, accounts) {
   const deployerApp = new DeployerApp(deployer, web3, deployerAccount, network);
   
   await deployerApp.deploys([ZDAI, ZUSDC], txConfig);
-  await deployerApp.deploy(Settings, requiredSubmissions, maximumTolerance, txConfig);
+  await deployerApp.deploy(Settings, requiredSubmissions, maximumTolerance, responseExpiry, txConfig);
   const artifacts = {
     Lenders,
     Loans,

--- a/migrations/utils/PoolDeployer.js
+++ b/migrations/utils/PoolDeployer.js
@@ -13,9 +13,6 @@ PoolDeployer.prototype.deployPool = async function(aggregatorName, tokenName, ZT
     const zTokenName = await zTokenInstance.symbol();
     console.log(`Deploying pool for token ${tokenName}...`);
     const {
-        requiredSubmissions,
-        maximumTolerance,
-        responseExpiry,
         tokens,
         aggregators
     } = this.deployConfig;
@@ -57,9 +54,7 @@ PoolDeployer.prototype.deployPool = async function(aggregatorName, tokenName, ZT
     const consensusInstance = await InterestConsensus.deployed();
     await consensusInstance.initialize(
       Lenders.address,
-      requiredSubmissions,
-      maximumTolerance,
-      responseExpiry
+      settingsInstance.address,
     );
 }
 

--- a/migrations/utils/PoolDeployer.js
+++ b/migrations/utils/PoolDeployer.js
@@ -32,7 +32,8 @@ PoolDeployer.prototype.deployPool = async function(aggregatorName, tokenName, ZT
         Loans,
         LendingPool,
         InterestConsensus,
-        ChainlinkPairAggregator
+        ChainlinkPairAggregator,
+        Settings,
     } = this.artifacts;
 
     await this.deployer.deployWith(`ChainlinkPairAggregator_${aggregatorName.toUpperCase()}`, ChainlinkPairAggregator, aggregatorAddress, txConfig);
@@ -40,13 +41,15 @@ PoolDeployer.prototype.deployPool = async function(aggregatorName, tokenName, ZT
     await this.deployer.deployWith(`InterestConsensus_${zTokenName}`, InterestConsensus, txConfig);
     await this.deployer.deployWith(`Lenders_${zTokenName}`, Lenders, ZToken.address, LendingPool.address, InterestConsensus.address, txConfig);
     await this.deployer.deployWith(`Loans_${zTokenName}`, Loans, ChainlinkPairAggregator.address, LendingPool.address, txConfig);
-  
+    
+    const settingsInstance = await Settings.deployed();
     const lendingPoolInstance = await LendingPool.deployed();
     await lendingPoolInstance.initialize(
       ZToken.address,
       tokenAddress,
       Lenders.address,
-      Loans.address
+      Loans.address,
+      settingsInstance.address,
     );
   
     await zTokenInstance.addMinter(LendingPool.address, txConfig);

--- a/scripts/lendingPool_deposit.js
+++ b/scripts/lendingPool_deposit.js
@@ -9,9 +9,9 @@ const ProcessArgs = require('./utils/ProcessArgs');
 const processArgs = new ProcessArgs();
 
 /** Process parameters: */
-const tokenName = 'DAI';
+const tokenName = 'USDC';
 const senderIndex = 0;
-const depositAmount = 3000;
+const depositAmount = 300000000;
 
 module.exports = async (callback) => {
     try {
@@ -25,7 +25,7 @@ module.exports = async (callback) => {
         const tokenAddress = tokens[tokenName];
         assert(tokenAddress, "Token address is undefined.");
 
-        const daiInstance = await ERC20.at(tokenAddress);
+        const tokenInstance = await ERC20.at(tokenAddress);
         const lendingPoolInstance = await LendingPoolInterface.at(lendingPoolAddress);
 
         const accounts = await web3.eth.getAccounts();
@@ -33,18 +33,17 @@ module.exports = async (callback) => {
         const sender = accounts[senderIndex];
         assert(sender, "Sender must be defined.");
 
-        const initialLendingPoolDaiBalance = await daiInstance.balanceOf(lendingPoolAddress);
+        const initialLendingPoolDaiBalance = await tokenInstance.balanceOf(lendingPoolAddress);
 
-        const senderDaiBalance = await daiInstance.balanceOf(sender);
-        assert(BigNumber(senderDaiBalance.toString()).gte(depositAmount), "Not enough DAI balance.");
+        const senderDaiBalance = await tokenInstance.balanceOf(sender);
+        assert(BigNumber(senderDaiBalance.toString()).gte(depositAmount), `Not enough ${tokenName} balance.`);
 
-        await daiInstance.approve(lendingPoolAddress, depositAmount, { from: sender });
+        await tokenInstance.approve(lendingPoolAddress, depositAmount, { from: sender });
 
-        await daiInstance.allowance(sender, lendingPoolAddress);
         const result = await lendingPoolInstance.deposit(depositAmount, { from: sender });
         console.log(toTxUrl(result));
 
-        const finalLendingPoolDaiBalance = await daiInstance.balanceOf(lendingPoolAddress);
+        const finalLendingPoolDaiBalance = await tokenInstance.balanceOf(lendingPoolAddress);
         console.log('');
         console.log(`Deposit ${tokenName}`);
         console.log('-'.repeat(11));

--- a/test/base/BaseConstructorTest.js
+++ b/test/base/BaseConstructorTest.js
@@ -1,0 +1,34 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t, NULL_ADDRESS } = require('../utils/consts');
+
+// Mock contracts
+
+// Smart contracts
+const Base = artifacts.require("./base/Base.sol");
+
+contract('BaseConstructorTest', function (accounts) {
+
+    withData({
+        _1_basic: [accounts[0], undefined, false],
+        _2_notSettings: [NULL_ADDRESS, 'SETTIGNS_MUST_BE_PROVIDED', true],
+    }, function(settingsAddress, expectedErrorMessage, mustFail) {
+        it(t('user', 'new', 'Should (or not) be able to create a new instance.', mustFail), async function() {
+            // Setup
+
+            try {
+                // Invocation
+                const result = await Base.new(settingsAddress);
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+});

--- a/test/base/BaseInitializeTest.js
+++ b/test/base/BaseInitializeTest.js
@@ -5,7 +5,7 @@ const { t, NULL_ADDRESS } = require('../utils/consts');
 // Mock contracts
 
 // Smart contracts
-const Base = artifacts.require("./base/Base.sol");
+const Base = artifacts.require("./mock/base/BaseMock.sol");
 
 contract('BaseInitializeTest', function (accounts) {
 
@@ -19,7 +19,7 @@ contract('BaseInitializeTest', function (accounts) {
 
             try {
                 // Invocation
-                const result = await instance.initialize(settingsAddress);
+                const result = await instance.externalInitialize(settingsAddress);
                 
                 // Assertions
                 assert(!mustFail, 'It should have failed because data is invalid.');

--- a/test/base/BaseInitializeTest.js
+++ b/test/base/BaseInitializeTest.js
@@ -13,7 +13,7 @@ contract('BaseInitializeTest', function (accounts) {
         _1_basic: [accounts[0], undefined, false],
         _2_notSettings: [NULL_ADDRESS, 'SETTINGS_MUST_BE_PROVIDED', true],
     }, function(settingsAddress, expectedErrorMessage, mustFail) {
-        it(t('user', 'initialize', 'Should (or not) be able to inintialize the new instance.', mustFail), async function() {
+        it(t('user', 'initialize', 'Should (or not) be able to initialize the new instance.', mustFail), async function() {
             // Setup
             const instance = await Base.new();
 

--- a/test/base/BaseInitializeTest.js
+++ b/test/base/BaseInitializeTest.js
@@ -7,17 +7,19 @@ const { t, NULL_ADDRESS } = require('../utils/consts');
 // Smart contracts
 const Base = artifacts.require("./base/Base.sol");
 
-contract('BaseConstructorTest', function (accounts) {
+contract('BaseInitializeTest', function (accounts) {
 
     withData({
-        _1_basic: [undefined, false],
-    }, function(expectedErrorMessage, mustFail) {
-        it(t('user', 'new', 'Should be able to create a new instance.', mustFail), async function() {
+        _1_basic: [accounts[0], undefined, false],
+        _2_notSettings: [NULL_ADDRESS, 'SETTIGNS_MUST_BE_PROVIDED', true],
+    }, function(settingsAddress, expectedErrorMessage, mustFail) {
+        it(t('user', 'initialize', 'Should (or not) be able to inintialize the new instance.', mustFail), async function() {
             // Setup
+            const instance = await Base.new();
 
             try {
                 // Invocation
-                const result = await Base.new();
+                const result = await instance.initialize(settingsAddress);
                 
                 // Assertions
                 assert(!mustFail, 'It should have failed because data is invalid.');

--- a/test/base/BaseInitializeTest.js
+++ b/test/base/BaseInitializeTest.js
@@ -11,7 +11,7 @@ contract('BaseInitializeTest', function (accounts) {
 
     withData({
         _1_basic: [accounts[0], undefined, false],
-        _2_notSettings: [NULL_ADDRESS, 'SETTIGNS_MUST_BE_PROVIDED', true],
+        _2_notSettings: [NULL_ADDRESS, 'SETTINGS_MUST_BE_PROVIDED', true],
     }, function(settingsAddress, expectedErrorMessage, mustFail) {
         it(t('user', 'initialize', 'Should (or not) be able to inintialize the new instance.', mustFail), async function() {
             // Setup

--- a/test/base/BaseWhenNotPausedTest.js
+++ b/test/base/BaseWhenNotPausedTest.js
@@ -58,7 +58,7 @@ contract('BaseWhenNotPausedTest', function (accounts) {
 
             try {
                 // Invocation
-                const result = await instance.externalWhenLendingPoolNotPaused({ from: senderAddress });
+                const result = await instance.externalWhenLendingPoolNotPaused(instance.address, { from: senderAddress });
                 
                 // Assertions
                 assert(!mustFail, 'It should have failed because data is invalid.');

--- a/test/base/BaseWhenNotPausedTest.js
+++ b/test/base/BaseWhenNotPausedTest.js
@@ -15,14 +15,15 @@ contract('BaseWhenNotPausedTest', function (accounts) {
     
     beforeEach('Setup for each test', async () => {
         settings = await Settings.new(1, 1);
-        instance = await BaseMock.new(settings.address);
+        instance = await BaseMock.new();
+        await instance.initialize(settings.address);
     });
 
     withData({
         _1_notPaused: [false, undefined, false],
-        _2_paused: [true, 'PLATFORM_OR_POOL_IS_PAUSED', true],
+        _2_paused: [true, 'PLATFORM_IS_PAUSED', true],
     }, function(callPause, expectedErrorMessage,mustFail) {
-        it(t('user', 'externalWhenNotPaused / Platform', 'Should (or not) be able to call function when it is/isnt paused.', mustFail), async function() {
+        it(t('user', 'whenNotPaused', 'Should (or not) be able to call function when it is/isnt paused.', mustFail), async function() {
             // Setup
             if (callPause) {
                 await settings.pause({ from: owner });
@@ -45,20 +46,19 @@ contract('BaseWhenNotPausedTest', function (accounts) {
     });
 
     withData({
-        _1_notPaused: [1, 2, false, undefined, false],
-        _2_paused: [2, 2, true, 'PLATFORM_OR_POOL_IS_PAUSED', true]
-    }, function(lendingIndex, senderIndex, callPause, expectedErrorMessage,mustFail) {
-        it(t('user', 'externalWhenNotPaused / Lending', 'Should (or not) be able to call function when a lending address is/isnt paused.', mustFail), async function() {
+        _1_notPaused: [2, false, undefined, false],
+        _2_paused: [2, true, 'LENDING_POOL_IS_PAUSED', true]
+    }, function(senderIndex, callPause, expectedErrorMessage,mustFail) {
+        it(t('user', 'whenLendingPoolNotPaused', 'Should (or not) be able to call function when a lending address is/isnt paused.', mustFail), async function() {
             // Setup
             const senderAddress = accounts[senderIndex];
-            const lendingPoolAddress = accounts[lendingIndex];
             if (callPause) {
-                await settings.pauseLendingPool(lendingPoolAddress, { from: owner });
+                await settings.pauseLendingPool(instance.address, { from: owner });
             }
 
             try {
                 // Invocation
-                const result = await instance.externalWhenNotPausedAn(lendingPoolAddress, { from: senderAddress });
+                const result = await instance.externalWhenLendingPoolNotPaused({ from: senderAddress });
                 
                 // Assertions
                 assert(!mustFail, 'It should have failed because data is invalid.');

--- a/test/base/BaseWhenNotPausedTest.js
+++ b/test/base/BaseWhenNotPausedTest.js
@@ -1,0 +1,74 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t } = require('../utils/consts');
+
+// Mock contracts
+const BaseMock = artifacts.require("./mock/base/BaseMock.sol");
+
+// Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
+
+contract('BaseWhenNotPausedTest', function (accounts) {
+    const owner = accounts[0];
+    let settings;
+    let instance;
+    
+    beforeEach('Setup for each test', async () => {
+        settings = await Settings.new(1, 1);
+        instance = await BaseMock.new(settings.address);
+    });
+
+    withData({
+        _1_notPaused: [false, undefined, false],
+        _2_paused: [true, 'PLATFORM_OR_POOL_IS_PAUSED', true],
+    }, function(callPause, expectedErrorMessage,mustFail) {
+        it(t('user', 'externalWhenNotPaused / Platform', 'Should (or not) be able to call function when it is/isnt paused.', mustFail), async function() {
+            // Setup
+            if (callPause) {
+                await settings.pause({ from: owner });
+            }
+
+            try {
+                // Invocation
+                const result = await instance.externalWhenNotPaused();
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+
+    withData({
+        _1_notPaused: [1, 2, false, undefined, false],
+        _2_paused: [2, 2, true, 'PLATFORM_OR_POOL_IS_PAUSED', true]
+    }, function(lendingIndex, senderIndex, callPause, expectedErrorMessage,mustFail) {
+        it(t('user', 'externalWhenNotPaused / Lending', 'Should (or not) be able to call function when a lending address is/isnt paused.', mustFail), async function() {
+            // Setup
+            const senderAddress = accounts[senderIndex];
+            const lendingPoolAddress = accounts[lendingIndex];
+            if (callPause) {
+                await settings.pauseLendingPool(lendingPoolAddress, { from: owner });
+            }
+
+            try {
+                // Invocation
+                const result = await instance.externalWhenNotPausedAn(lendingPoolAddress, { from: senderAddress });
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+});

--- a/test/base/BaseWhenNotPausedTest.js
+++ b/test/base/BaseWhenNotPausedTest.js
@@ -16,7 +16,7 @@ contract('BaseWhenNotPausedTest', function (accounts) {
     beforeEach('Setup for each test', async () => {
         settings = await Settings.new(1, 1);
         instance = await BaseMock.new();
-        await instance.initialize(settings.address);
+        await instance.externalInitialize(settings.address);
     });
 
     withData({

--- a/test/base/BaseWhenNotPausedTest.js
+++ b/test/base/BaseWhenNotPausedTest.js
@@ -14,7 +14,7 @@ contract('BaseWhenNotPausedTest', function (accounts) {
     let instance;
     
     beforeEach('Setup for each test', async () => {
-        settings = await Settings.new(1, 1);
+        settings = await Settings.new(1, 1, 1);
         instance = await BaseMock.new();
         await instance.externalInitialize(settings.address);
     });

--- a/test/base/BaseWhenPausedTest.js
+++ b/test/base/BaseWhenPausedTest.js
@@ -1,0 +1,74 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t } = require('../utils/consts');
+
+// Mock contracts
+const BaseMock = artifacts.require("./mock/base/BaseMock.sol");
+
+// Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
+
+contract('BaseWhenPausedTest', function (accounts) {
+    const owner = accounts[0];
+    let settings;
+    let instance;
+    
+    beforeEach('Setup for each test', async () => {
+        settings = await Settings.new(1, 1);
+        instance = await BaseMock.new(settings.address);
+    });
+
+    withData({
+        _1_notPaused: [false, 'PLATFORM_OR_POOL_IS_NOT_PAUSED', true],
+        _2_paused: [true, undefined, false],
+    }, function(callpause, expectedErrorMessage, mustFail) {
+        it(t('user', 'externalWhenPaused / Platform', 'Should (or not) be able to call function when it is/isnt paused.', mustFail), async function() {
+            // Setup
+            if (callpause) {
+                await settings.pause({ from: owner });
+            }
+
+            try {
+                // Invocation
+                const result = await instance.externalWhenPaused();
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+
+    withData({
+        _1_notPaused: [1, 2, false, 'PLATFORM_OR_POOL_IS_NOT_PAUSED', true],
+        _2_paused: [2, 2, true, undefined, false]
+    }, function(lendingPoolIndex, senderIndex, callPause, expectedErrorMessage,mustFail) {
+        it(t('user', 'externalWhenNotPaused / Lending', 'Should (or not) be able to call function when a lending address is/isnt paused.', mustFail), async function() {
+            // Setup
+            const senderAddress = accounts[senderIndex];
+            const lendingPoolAddress = accounts[lendingPoolIndex];
+            if (callPause) {
+                await settings.pauseLendingPool(lendingPoolAddress, { from: owner });
+            }
+
+            try {
+                // Invocation
+                const result = await instance.externalWhenPausedAn(lendingPoolAddress, { from: senderAddress });
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+});

--- a/test/base/BaseWhenPausedTest.js
+++ b/test/base/BaseWhenPausedTest.js
@@ -14,7 +14,7 @@ contract('BaseWhenPausedTest', function (accounts) {
     let instance;
     
     beforeEach('Setup for each test', async () => {
-        settings = await Settings.new(1, 1);
+        settings = await Settings.new(1, 1, 1);
         instance = await BaseMock.new();
         await instance.externalInitialize(settings.address);
     });

--- a/test/base/BaseWhenPausedTest.js
+++ b/test/base/BaseWhenPausedTest.js
@@ -15,14 +15,15 @@ contract('BaseWhenPausedTest', function (accounts) {
     
     beforeEach('Setup for each test', async () => {
         settings = await Settings.new(1, 1);
-        instance = await BaseMock.new(settings.address);
+        instance = await BaseMock.new();
+        await instance.initialize(settings.address);
     });
 
     withData({
-        _1_notPaused: [false, 'PLATFORM_OR_POOL_IS_NOT_PAUSED', true],
+        _1_notPaused: [false, 'PLATFORM_IS_NOT_PAUSED', true],
         _2_paused: [true, undefined, false],
     }, function(callpause, expectedErrorMessage, mustFail) {
-        it(t('user', 'externalWhenPaused / Platform', 'Should (or not) be able to call function when it is/isnt paused.', mustFail), async function() {
+        it(t('user', 'externalWhenPaused', 'Should (or not) be able to call function when it is/isnt paused.', mustFail), async function() {
             // Setup
             if (callpause) {
                 await settings.pause({ from: owner });
@@ -45,20 +46,19 @@ contract('BaseWhenPausedTest', function (accounts) {
     });
 
     withData({
-        _1_notPaused: [1, 2, false, 'PLATFORM_OR_POOL_IS_NOT_PAUSED', true],
-        _2_paused: [2, 2, true, undefined, false]
-    }, function(lendingPoolIndex, senderIndex, callPause, expectedErrorMessage,mustFail) {
-        it(t('user', 'externalWhenNotPaused / Lending', 'Should (or not) be able to call function when a lending address is/isnt paused.', mustFail), async function() {
+        _1_notPaused: [2, false, 'LENDING_POOL_IS_NOT_PAUSED', true],
+        _2_paused: [2, true, undefined, false]
+    }, function(senderIndex, callPause, expectedErrorMessage,mustFail) {
+        it(t('user', 'externalWhenNotPaused', 'Should (or not) be able to call function when a lending address is/isnt paused.', mustFail), async function() {
             // Setup
             const senderAddress = accounts[senderIndex];
-            const lendingPoolAddress = accounts[lendingPoolIndex];
             if (callPause) {
-                await settings.pauseLendingPool(lendingPoolAddress, { from: owner });
+                await settings.pauseLendingPool(instance.address, { from: owner });
             }
 
             try {
                 // Invocation
-                const result = await instance.externalWhenPausedAn(lendingPoolAddress, { from: senderAddress });
+                const result = await instance.externalWhenLendingPoolPaused({ from: senderAddress });
                 
                 // Assertions
                 assert(!mustFail, 'It should have failed because data is invalid.');

--- a/test/base/BaseWhenPausedTest.js
+++ b/test/base/BaseWhenPausedTest.js
@@ -58,7 +58,7 @@ contract('BaseWhenPausedTest', function (accounts) {
 
             try {
                 // Invocation
-                const result = await instance.externalWhenLendingPoolPaused({ from: senderAddress });
+                const result = await instance.externalWhenLendingPoolPaused(instance.address, { from: senderAddress });
                 
                 // Assertions
                 assert(!mustFail, 'It should have failed because data is invalid.');

--- a/test/base/BaseWhenPausedTest.js
+++ b/test/base/BaseWhenPausedTest.js
@@ -16,7 +16,7 @@ contract('BaseWhenPausedTest', function (accounts) {
     beforeEach('Setup for each test', async () => {
         settings = await Settings.new(1, 1);
         instance = await BaseMock.new();
-        await instance.initialize(settings.address);
+        await instance.externalInitialize(settings.address);
     });
 
     withData({

--- a/test/base/InterestConsensusHashesTest.js
+++ b/test/base/InterestConsensusHashesTest.js
@@ -5,6 +5,7 @@ const { hashRequest, signHash, hashResponse } = require('../utils/hashes');
 const ethUtil = require('ethereumjs-util')
 
 // Smart contracts
+const Mock = artifacts.require("./mock/util/Mock.sol");
 const InterestConsensusMock = artifacts.require("./mock/base/InterestConsensusMock.sol");
 
 // constants
@@ -17,8 +18,9 @@ contract('InterestConsensus hashRequest and hashReponse', function (accounts) {
     let instance
 
     beforeEach('Setup for each test', async () => {
+        const settings = await Mock.new();
         instance = await InterestConsensusMock.new()
-        await instance.initialize(lendersAddress, submissions, tolerance, THIRTY_DAYS)
+        await instance.initialize(lendersAddress, settings.address);
     })
 
     withData({

--- a/test/base/InterestConsensusInitializeTest.js
+++ b/test/base/InterestConsensusInitializeTest.js
@@ -1,22 +1,21 @@
 // JS Libraries
 const withData = require('leche').withData;
-const { t, NULL_ADDRESS, THIRTY_DAYS } = require('../utils/consts');
+const { t, NULL_ADDRESS } = require('../utils/consts');
 
 // Smart contracts
+const Mock = artifacts.require("./mock/util/Mock.sol");
 const InterestConsensus = artifacts.require("./base/InterestConsensus.sol");
 const Lenders = artifacts.require("./base/Lenders.sol");
 
 contract('InterestConsensusInitializeTest', function (accounts) {
 
     withData({
-        _1_no_reqsubmissions: [true, 0, 1, 'MUST_PROVIDE_REQUIRED_SUBS', true],
-        _2_no_lenders: [false, 1, 1, 'MUST_PROVIDE_LENDER_INFO', true],
-        _3_no_maxtolerance: [true, 1, 0, undefined, false],
-        _4_all_provided: [true, 1, 1, undefined, false],
+        _1_no_settings: [true, false, 'MUST_PROVIDE_SETTINGS', true],
+        _2_no_lenders: [false, true, 'MUST_PROVIDE_LENDER_INFO', true],
+        _4_all_provided: [true, true, undefined, false],
     }, function(
         provideLenders,
-        requiredSubmissions,
-        maximumTolerance,
+        provideSettings,
         expectedErrorMessage,
         mustFail
     ) {    
@@ -24,14 +23,14 @@ contract('InterestConsensusInitializeTest', function (accounts) {
             try {
                 // Setup
                 const instance = await InterestConsensus.new();
-                const lenders = await Lenders.new(accounts[1], accounts[2], instance.address)
-                const lendersAddress = provideLenders ? lenders.address : NULL_ADDRESS
+                const settings = await Mock.new();
+                const lenders = await Lenders.new(accounts[1], accounts[2], instance.address);
+                const lendersAddress = provideLenders ? lenders.address : NULL_ADDRESS;
+                const settingsAddress = provideSettings ? settings.address : NULL_ADDRESS;
 
                 let result = await instance.initialize(
                     lendersAddress,
-                    requiredSubmissions,
-                    maximumTolerance,
-                    THIRTY_DAYS
+                    settingsAddress,
                 )
 
                 // Assertions

--- a/test/base/InterestConsensusInitializeTest.js
+++ b/test/base/InterestConsensusInitializeTest.js
@@ -12,7 +12,7 @@ contract('InterestConsensusInitializeTest', function (accounts) {
     withData({
         _1_no_settings: [true, false, 'MUST_PROVIDE_SETTINGS', true],
         _2_no_lenders: [false, true, 'MUST_PROVIDE_LENDER_INFO', true],
-        _4_all_provided: [true, true, undefined, false],
+        _3_all_provided: [true, true, undefined, false],
     }, function(
         provideLenders,
         provideSettings,

--- a/test/base/InterestConsensusModifiersTest.js
+++ b/test/base/InterestConsensusModifiersTest.js
@@ -1,13 +1,12 @@
 // JS Libraries
 const withData = require('leche').withData;
-const { t, THIRTY_DAYS } = require('../utils/consts');
+const { t } = require('../utils/consts');
 
 // Smart contracts
-const InterestConsensus = artifacts.require("./base/InterestConsensusModifiersMock.sol");
+const InterestConsensus = artifacts.require("./mock/base/InterestConsensusModifiersMock.sol");
+const Mock = artifacts.require("./mock/util/Mock.sol");
 
 contract('InterestConsensusModifiersTest', function (accounts) {
-    const reqSubmissions = 1
-    const maxTolerance = 1
 
     withData({
         _1_not_lenders: [accounts[1], accounts[3], 'Address has no permissions.', true],
@@ -21,12 +20,11 @@ contract('InterestConsensusModifiersTest', function (accounts) {
         it(t('user', 'new', 'Should (or not) be able to call the function', mustFail), async function() {
             try {
                 // Setup
+                const settings = await Mock.new();
                 const instance = await InterestConsensus.new();
                 await instance.initialize(
                     lendersAddress,
-                    reqSubmissions,
-                    maxTolerance,
-                    THIRTY_DAYS
+                    settings.address,
                 )
 
                 const result = await instance.externalIsLenders({ from:  msgSender })

--- a/test/base/InterestConsensusProcessRequestTest.js
+++ b/test/base/InterestConsensusProcessRequestTest.js
@@ -12,6 +12,7 @@ const ethUtil = require('ethereumjs-util')
 const { interestConsensus } = require('../utils/events');
 
 // Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
 const InterestConsensus = artifacts.require("./mock/base/InterestConsensus.sol");
 
 
@@ -89,8 +90,9 @@ contract('InterestConsensusProcessRequestTest', function (accounts) {
     ) {    
         it(t('user', 'new', 'Should accept/not accept a nodes response', false), async function() {
             // set up contract
-            instance = await InterestConsensus.new()
-            await instance.initialize(lendersContract, reqSubmissions, tolerance, THIRTY_DAYS)
+            const settings = await Settings.new(reqSubmissions, tolerance, THIRTY_DAYS);
+            instance = await InterestConsensus.new();
+            await instance.initialize(lendersContract, settings.address);
 
             await instance.addSigner(nodeOne)
             await instance.addSigner(nodeTwo)

--- a/test/base/InterestConsensusProcessResponseTest.js
+++ b/test/base/InterestConsensusProcessResponseTest.js
@@ -12,6 +12,7 @@ const ethUtil = require('ethereumjs-util')
 const { interestConsensus } = require('../utils/events');
 
 // Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
 const InterestConsensusMock = artifacts.require("./mock/base/InterestConsensusMock.sol");
 
 
@@ -20,7 +21,7 @@ contract('InterestConsensusProcessResponseTest', function (accounts) {
     const lendersContract = accounts[1]
     const nodeAddress = accounts[2]
     const submissions = 5
-  const tolerance = 0
+    const tolerance = 0
     const endTime = 34567
     const lender = accounts[3]
 
@@ -63,8 +64,9 @@ contract('InterestConsensusProcessResponseTest', function (accounts) {
     ) {    
         it(t('user', 'new', 'Should accept/not accept a nodes response', false), async function() {
             // set up contract
+            const settings = await Settings.new(submissions, tolerance, THIRTY_DAYS);
             instance = await InterestConsensusMock.new()
-            await instance.initialize(lendersContract, submissions, tolerance, THIRTY_DAYS)
+            await instance.initialize(lendersContract, settings.address)
 
             const currentTime = await getLatestTimestamp()
             const responseTime = mockExpiredResponse ?

--- a/test/base/LendersInitializeTest.js
+++ b/test/base/LendersInitializeTest.js
@@ -8,27 +8,33 @@ const Mock = artifacts.require("./mock/util/Mock.sol");
 // Smart contracts
 const Lenders = artifacts.require("./base/Lenders.sol");
 
-contract('LendersConstructorTest', function (accounts) {
+contract('LendersInitializeTest', function (accounts) {
     let zTokenInstance;
     let lendingPoolInstance;
     let interestConsensusInstance;
+    let settingsInstance;
+    let instance;
 
     beforeEach('Setup for each test', async () => {
         zTokenInstance = await Mock.new();
         lendingPoolInstance = await Mock.new();
         interestConsensusInstance = await Mock.new();
+        settingsInstance = await Mock.new();
+        instance = await Lenders.new();
     });
 
     withData({
-        _1_basic: [true, true, true, undefined, false],
-        _2_notzTokenInstance: [false, true, true, 'zToken address is required.', true],
-        _3_notLendingPoolInstance: [true, false, true, 'LendingPool address is required.', true],
-        _4_notConsensusInstance: [true, true, false, 'Consensus address is required.', true],
-        _5_notzTokenInstance_notLendingPoolInstance: [false, false, true, 'zToken address is required.', true],
+        _1_basic: [true, true, true, true, undefined, false],
+        _2_notzTokenInstance: [false, true, true, true, 'ZTOKEN_MUST_BE_PROVIDED', true],
+        _3_notLendingPoolInstance: [true, false, true, true, 'LENDING_POOL_MUST_BE_PROVIDED', true],
+        _4_notConsensusInstance: [true, true, false, true, 'CONSENSUS_MUST_BE_PROVIDED', true],
+        _5_notzTokenInstance_notLendingPoolInstance: [false, false, true, true, 'ZTOKEN_MUST_BE_PROVIDED', true],
+        _6_notSettingsInstance: [true, true, true, false, 'SETTINGS_MUST_BE_PROVIDED', true],
     }, function(
         createzTokenInstance,
         createLendingPoolInstance,
         createConsensusInstance,
+        createSettingsInstance,
         expectedErrorMessage,
         mustFail
     ) {    
@@ -37,19 +43,20 @@ contract('LendersConstructorTest', function (accounts) {
             const zTokenAddress = createzTokenInstance ? zTokenInstance.address : NULL_ADDRESS;
             const lendingPoolAddress = createLendingPoolInstance ? lendingPoolInstance.address : NULL_ADDRESS;
             const consensusAddress = createConsensusInstance ? interestConsensusInstance.address : NULL_ADDRESS;
+            const settingsAddress = createSettingsInstance ? settingsInstance.address : NULL_ADDRESS;
 
             try {
                 // Invocation
-                const result = await Lenders.new(
+                const result = await instance.initialize(
                     zTokenAddress,
                     lendingPoolAddress,
                     consensusAddress,
+                    settingsAddress,
                 );
                 
                 // Assertions
                 assert(!mustFail, 'It should have failed because data is invalid.');
                 assert(result);
-                assert(result.address);
             } catch (error) {
                 // Assertions
                 assert(mustFail);

--- a/test/base/LendersModifiersTest.js
+++ b/test/base/LendersModifiersTest.js
@@ -12,21 +12,23 @@ contract('LendersModifiersTest', function (accounts) {
     beforeEach('Setup for each test', async () => { });
 
     withData({
-        _1_zTokenSender: [accounts[0], accounts[1], accounts[2], accounts[0], undefined, false],
-        _2_lendingPoolSender: [accounts[0], accounts[1], accounts[2], accounts[1], 'Address has no permissions.', true],
-        _3_consensusSender: [accounts[0], accounts[1], accounts[2], accounts[2], 'Address has no permissions.', true],
-        _4_notValidSender: [accounts[0], accounts[1], accounts[2], accounts[3], 'Address has no permissions.', true],
+        _1_zTokenSender: [accounts[0], accounts[1], accounts[2], accounts[3], accounts[0], undefined, false],
+        _2_lendingPoolSender: [accounts[0], accounts[1], accounts[2], accounts[3], accounts[1], 'Address has no permissions.', true],
+        _3_consensusSender: [accounts[0], accounts[1], accounts[2], accounts[3], accounts[2], 'Address has no permissions.', true],
+        _4_notValidSender: [accounts[0], accounts[1], accounts[2], accounts[3], accounts[3], 'Address has no permissions.', true],
     }, function(
         zTokenAddress,
         lendingPoolAddress,
         consensusAddress,
+        settingsAddress,
         sender,
         expectedErrorMessage,
         mustFail
     ) {    
         it(t('user', 'isZToken', 'Should able (or not) to call function with modifier isZToken.', mustFail), async function() {
             // Setup
-            const instance = await Lenders.new(zTokenAddress, lendingPoolAddress, consensusAddress);
+            const instance = await Lenders.new();
+            await instance.initialize(zTokenAddress, lendingPoolAddress, consensusAddress, settingsAddress);
 
             try {
                 // Invocation
@@ -45,21 +47,23 @@ contract('LendersModifiersTest', function (accounts) {
     });
 
     withData({
-        _1_zTokenSender: [accounts[0], accounts[1], accounts[2], accounts[0], 'Address has no permissions.', true],
-        _2_lendingPoolSender: [accounts[0], accounts[1], accounts[2], accounts[1], undefined, false],
-        _3_consensusSender: [accounts[0], accounts[1], accounts[2], accounts[2], 'Address has no permissions.', true],
-        _4_notValidSender: [accounts[0], accounts[1], accounts[2], accounts[3], 'Address has no permissions.', true],
+        _1_zTokenSender: [accounts[0], accounts[1], accounts[2], accounts[3], accounts[0], 'Address has no permissions.', true],
+        _2_lendingPoolSender: [accounts[0], accounts[1], accounts[2], accounts[3], accounts[1], undefined, false],
+        _3_consensusSender: [accounts[0], accounts[1], accounts[2], accounts[3], accounts[2], 'Address has no permissions.', true],
+        _4_notValidSender: [accounts[0], accounts[1], accounts[2], accounts[4], accounts[3], 'Address has no permissions.', true],
     }, function(
         zTokenAddress,
         lendingPoolAddress,
         consensusAddress,
+        settingsAddress,
         sender,
         expectedErrorMessage,
         mustFail
     ) {    
         it(t('user', 'isLendingPool', 'Should able (or not) to call function with modifier isLendingPool.', mustFail), async function() {
             // Setup
-            const instance = await Lenders.new(zTokenAddress, lendingPoolAddress, consensusAddress);
+            const instance = await Lenders.new();
+            await instance.initialize(zTokenAddress, lendingPoolAddress, consensusAddress, settingsAddress);
 
             try {
                 // Invocation
@@ -78,19 +82,21 @@ contract('LendersModifiersTest', function (accounts) {
     });
 
     withData({
-        _1_validAddress: [accounts[0], accounts[1], accounts[2], accounts[1], undefined, false],
-        _2_invalidAddress: [accounts[0], accounts[1], accounts[2], NULL_ADDRESS, 'Address is required.', true],
+        _1_validAddress: [accounts[0], accounts[1], accounts[2], accounts[3], accounts[1], undefined, false],
+        _2_invalidAddress: [accounts[0], accounts[1], accounts[2], accounts[3], NULL_ADDRESS, 'Address is required.', true],
     }, function(
         zTokenAddress,
         lendingPoolAddress,
         consensusAddress,
+        settingsAddress,
         sender,
         expectedErrorMessage,
         mustFail
     ) {    
         it(t('user', 'isValid', 'Should able (or not) to call function with modifier isValid.', mustFail), async function() {
             // Setup
-            const instance = await Lenders.new(zTokenAddress, lendingPoolAddress, consensusAddress);
+            const instance = await Lenders.new();
+            await instance.initialize(zTokenAddress, lendingPoolAddress, consensusAddress, settingsAddress);
 
             try {
                 // Invocation

--- a/test/base/LendersSetAccruedInterestTest.js
+++ b/test/base/LendersSetAccruedInterestTest.js
@@ -10,7 +10,7 @@ const Mock = artifacts.require("./mock/util/Mock.sol");
 const Lenders = artifacts.require("./mock/base/LendersMock.sol");
 const InterestConsensus = artifacts.require("./mock/base/InterestConsensus.sol");
 
-contract('LendersWithdrawInterestTest', function (accounts) {
+contract('LendersSetAccruedInterestTest', function (accounts) {
     let instance;
     let zTokenInstance;
     let lendingPoolInstance;
@@ -55,10 +55,13 @@ contract('LendersWithdrawInterestTest', function (accounts) {
         zTokenInstance = await Mock.new();
         lendingPoolInstance = await Mock.new();
         interestConsensusInstance = await Mock.new();
-        instance = await Lenders.new(
+        settingsInstance = await Mock.new();
+        instance = await Lenders.new();
+        await instance.initialize(
             zTokenInstance.address,
             lendingPoolInstance.address,
-            interestConsensusInstance.address
+            interestConsensusInstance.address,
+            settingsInstance.address,
         );
 
         interestConsensusTemplate = await InterestConsensus.new()

--- a/test/base/LendersWithdrawInterestTest.js
+++ b/test/base/LendersWithdrawInterestTest.js
@@ -14,15 +14,19 @@ contract('LendersWithdrawInterestTest', function (accounts) {
     let zTokenInstance;
     let lendingPoolInstance;
     let interestConsensusInstance;
+    let settingsInstance;
     
     beforeEach('Setup for each test', async () => {
         zTokenInstance = await Mock.new();
         lendingPoolInstance = await Mock.new();
         interestConsensusInstance = await Mock.new();
-        instance = await Lenders.new(
+        settingsInstance = await Mock.new();
+        instance = await Lenders.new();
+        await instance.initialize(
             zTokenInstance.address,
             lendingPoolInstance.address,
-            interestConsensusInstance.address
+            interestConsensusInstance.address,
+            settingsInstance.address,
         );
     });
 

--- a/test/base/LendingPoolCreateLoanTest.js
+++ b/test/base/LendingPoolCreateLoanTest.js
@@ -24,6 +24,8 @@ contract('LendingPoolCreateLoanTest', function (accounts) {
         daiInstance = await Mock.new();
         instance = await LendingPool.new();
         interestConsensusInstance = await Mock.new();
+        interestConsensusInstance = await Mock.new();
+        const settingsInstance = await Mock.new();
 
         lendersInstance = await Lenders.new(
           zTokenInstance.address,
@@ -36,6 +38,7 @@ contract('LendingPoolCreateLoanTest', function (accounts) {
             daiInstance.address,
             lendersInstance.address,
             loansAddress,
+            settingsInstance.address
         );
     });
 

--- a/test/base/LendingPoolDepositTest.js
+++ b/test/base/LendingPoolDepositTest.js
@@ -28,6 +28,7 @@ contract('LendingPoolDepositTest', function (accounts) {
         loansInstance = await Mock.new();
         interestConsensusInstance = await Mock.new();
         instance = await LendingPool.new();
+        const settingsInstance = await Mock.new();
 
         lendersInstance = await Lenders.new(
           zTokenInstance.address,
@@ -40,6 +41,7 @@ contract('LendingPoolDepositTest', function (accounts) {
             daiInstance.address,
             lendersInstance.address,
             loansInstance.address,
+            settingsInstance.address,
         );
     });
 

--- a/test/base/LendingPoolInitializeTest.js
+++ b/test/base/LendingPoolInitializeTest.js
@@ -31,7 +31,7 @@ contract('LendingPoolInitializeTest', function (accounts) {
         _5_notLoanInfo: [true, true, true, false, true, 'Loans address is required.', true],
         _5_notZdai_notLoanInfo: [false, true, true, false, true, 'zToken address is required.', true],
         _6_notDai_notLenderInfo: [true, false, false, true, true, 'Token address is required.', true],
-        _7_notSettings: [true, true, true, true, false, 'SETTIGNS_MUST_BE_PROVIDED', true],
+        _7_notSettings: [true, true, true, true, false, 'SETTINGS_MUST_BE_PROVIDED', true],
     }, function(
         createZdai,
         createDai,

--- a/test/base/LendingPoolInitializeTest.js
+++ b/test/base/LendingPoolInitializeTest.js
@@ -13,27 +13,31 @@ contract('LendingPoolInitializeTest', function (accounts) {
     let daiInstance;
     let lendersInstance;
     let loansInstance;
+    let settingsInstance;
     
     beforeEach('Setup for each test', async () => {
         zTokenInstance = await Mock.new();
         daiInstance = await Mock.new();
         lendersInstance = await Mock.new();
         loansInstance = await Mock.new();
+        settingsInstance = await Mock.new();
     });
 
     withData({
-        _1_basic: [true, true, true, true, undefined, false],
-        _2_notZdai: [false, true, true, true, 'zToken address is required.', true],
-        _3_notDai: [true, false, true, true, 'Token address is required.', true],
-        _4_notLenderInfo: [true, true, false, true, 'Lenders address is required.', true],
-        _5_notLoanInfo: [true, true, true, false, 'Loans address is required.', true],
-        _5_notZdai_notLoanInfo: [false, true, true, false, 'zToken address is required.', true],
-        _6_notDai_notLenderInfo: [true, false, false, true, 'Token address is required.', true],
+        _1_basic: [true, true, true, true, true, undefined, false],
+        _2_notZdai: [false, true, true, true, true, 'zToken address is required.', true],
+        _3_notDai: [true, false, true, true, true, 'Token address is required.', true],
+        _4_notLenderInfo: [true, true, false, true, true, 'Lenders address is required.', true],
+        _5_notLoanInfo: [true, true, true, false, true, 'Loans address is required.', true],
+        _5_notZdai_notLoanInfo: [false, true, true, false, true, 'zToken address is required.', true],
+        _6_notDai_notLenderInfo: [true, false, false, true, true, 'Token address is required.', true],
+        _7_notSettings: [true, true, true, true, false, 'SETTIGNS_MUST_BE_PROVIDED', true],
     }, function(
         createZdai,
         createDai,
         createLenderInfo,
         createLoanInfo,
+        createSettings,
         expectedErrorMessage,
         mustFail
     ) {    
@@ -44,6 +48,7 @@ contract('LendingPoolInitializeTest', function (accounts) {
             const daiAddress = createDai ? daiInstance.address : NULL_ADDRESS;
             const lendersAddress = createLenderInfo ? lendersInstance.address : NULL_ADDRESS;
             const loanInfoAddress = createLoanInfo ? loansInstance.address : NULL_ADDRESS;
+            const settingsAddress = createSettings ? settingsInstance.address : NULL_ADDRESS;
 
             try {
                 // Invocation
@@ -52,6 +57,7 @@ contract('LendingPoolInitializeTest', function (accounts) {
                     daiAddress,
                     lendersAddress,
                     loanInfoAddress,
+                    settingsAddress,
                 );;
                 
                 // Assertions

--- a/test/base/LendingPoolLiquidationPaymentTest.js
+++ b/test/base/LendingPoolLiquidationPaymentTest.js
@@ -25,6 +25,7 @@ contract('LendingPoolLiquidationPaymentTest', function (accounts) {
         daiInstance = await Mock.new();
         instance = await LendingPool.new();
         interestConsensusInstance = await Mock.new();
+        const settingsInstance = await Mock.new();
 
         lendersInstance = await Lenders.new(
           zTokenInstance.address,
@@ -37,6 +38,7 @@ contract('LendingPoolLiquidationPaymentTest', function (accounts) {
             daiInstance.address,
             lendersInstance.address,
             loansInstance,
+            settingsInstance.address,
         );
     });
 

--- a/test/base/LendingPoolRepayTest.js
+++ b/test/base/LendingPoolRepayTest.js
@@ -25,6 +25,7 @@ contract('LendingPoolRepayTest', function (accounts) {
         daiInstance = await Mock.new();
         instance = await LendingPool.new();
         interestConsensusInstance = await Mock.new();
+        const settingsInstance = await Mock.new();
 
         lendersInstance = await Lenders.new(
           zTokenInstance.address,
@@ -37,6 +38,7 @@ contract('LendingPoolRepayTest', function (accounts) {
             daiInstance.address,
             lendersInstance.address,
             loansAddress,
+            settingsInstance.address,
         );
     });
 

--- a/test/base/LendingPoolWithdrawInterestTest.js
+++ b/test/base/LendingPoolWithdrawInterestTest.js
@@ -1,0 +1,89 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t } = require('../utils/consts');
+const { lendingPool } = require('../utils/events');
+const BurnableInterfaceEncoder = require('../utils/encoders/BurnableInterfaceEncoder');
+
+// Mock contracts
+const Mock = artifacts.require("./mock/util/Mock.sol");
+
+// Smart contracts
+const Lenders = artifacts.require("./mock/base/LendersMock.sol");
+const LendingPool = artifacts.require("./base/LendingPool.sol");
+
+contract('LendingPoolWithdrawInterestTest', function (accounts) {
+    const burnableInterfaceEncoder = new BurnableInterfaceEncoder(web3);
+    let instance;
+    let zTokenInstance;
+    let lendingTokenInstance;
+    let loansInstance;
+    let consensusInstance;
+    let settingsInstance;
+    let lendersInstance;
+    
+    beforeEach('Setup for each test', async () => {
+        loansInstance = await Mock.new();
+        consensusInstance = await Mock.new();
+        settingsInstance = await Mock.new();
+        zTokenInstance = await Mock.new();
+        lendingTokenInstance = await Mock.new();
+        lendersInstance = await Lenders.new();
+        
+        instance = await LendingPool.new();
+        await lendersInstance.initialize(
+            zTokenInstance.address,
+            instance.address,
+            consensusInstance.address,
+            settingsInstance.address,
+        );
+        await instance.initialize(
+            zTokenInstance.address,
+            lendingTokenInstance.address,
+            lendersInstance.address,
+            loansInstance.address,
+            settingsInstance.address,
+        );
+    });
+
+    withData({
+        _1_basic: [accounts[0], true, 10, 10, 10, undefined, false],
+        _2_basic: [accounts[0], true, 40, 30, 25, undefined, false],
+        _3_basic: [accounts[0], true, 40, 25, 30, undefined, false],
+        _4_transferFail: [accounts[1], false, 50, 50, 50, 'Transfer was not successful.', true],
+        _5_notEnoughBalance: [accounts[1], true, 49, 50, 50, 'NOT_ENOUGH_LENDING_TOKEN_BALANCE', true],
+    }, function(lender, transfer, currentBalanceOf, amountToWithdraw, totalNotWithdrawn, expectedErrorMessage, mustFail) {
+        it(t('user', 'withdrawInterest', 'Should able (or not) to withdraw the interest.', mustFail), async function() {
+            // Setup
+            await lendersInstance.mockLenderInfo(
+                lender,
+                Math.floor(Date.now() / 1000),
+                totalNotWithdrawn,
+                totalNotWithdrawn
+            );
+            
+            const encodeTransfer = burnableInterfaceEncoder.encodeTransfer();
+            await lendingTokenInstance.givenMethodReturnBool(encodeTransfer, transfer);
+            const encodeBalanceOf = burnableInterfaceEncoder.encodeBalanceOf();
+            await lendingTokenInstance.givenMethodReturnUint(encodeBalanceOf, currentBalanceOf.toString());
+
+            try {
+                // Invocation
+                const result = await instance.withdrawInterest(amountToWithdraw, { from: lender });
+
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+                const interestWithdrawn = totalNotWithdrawn > amountToWithdraw ? amountToWithdraw : totalNotWithdrawn;
+                lendingPool
+                    .interestWithdrawn(result)
+                    .emitted(lender, interestWithdrawn);
+
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+});

--- a/test/base/LendingPoolWithdrawTest.js
+++ b/test/base/LendingPoolWithdrawTest.js
@@ -21,10 +21,12 @@ contract('LendingPoolWithdrawTest', function (accounts) {
     let daiInstance;
     let loansInstance;
     let consensusInstance;
+    let settingsInstance;
     
     beforeEach('Setup for each test', async () => {
         loansInstance = await Mock.new();
         consensusInstance = await Mock.new();
+        settingsInstance = await Mock.new();
         instance = await LendingPool.new();
     });
 
@@ -36,7 +38,7 @@ contract('LendingPoolWithdrawTest', function (accounts) {
             // Setup
             zTokenInstance = await Mock.new();
             daiInstance = await Mock.new();
-            await initContracts(instance, zTokenInstance, consensusInstance, daiInstance, loansInstance, Lenders);
+            await initContracts(settingsInstance, instance, zTokenInstance, consensusInstance, daiInstance, loansInstance, Lenders);
             const encodeTransfer = burnableInterfaceEncoder.encodeTransfer();
             await daiInstance.givenMethodReturnBool(encodeTransfer, transfer);
 
@@ -69,7 +71,7 @@ contract('LendingPoolWithdrawTest', function (accounts) {
             zTokenInstance = await ZDai.new();
             daiInstance = await DAI.new();
             await zTokenInstance.addMinter(instance.address);
-            await initContracts(instance, zTokenInstance, consensusInstance, daiInstance, loansInstance, Lenders);
+            await initContracts(settingsInstance, instance, zTokenInstance, consensusInstance, daiInstance, loansInstance, Lenders);
             await daiInstance.approve(instance.address, depositAmount, { from: depositSender });
             await instance.deposit(depositAmount, { from: depositSender });
             

--- a/test/base/LoansIsCollateralSentEnoughTest.js
+++ b/test/base/LoansIsCollateralSentEnoughTest.js
@@ -32,11 +32,13 @@ contract('LoansIsCollateralSentEnoughTest', function (accounts) {
         const zToken = await Mock.new();
         lendingToken = await Mock.new();
         const lenders = await Mock.new();
+        const settings = await Mock.new();
         await lendingPoolInstance.initialize(
             zToken.address,
             lendingToken.address,
             lenders.address,
             instance.address,
+            settings.address,
         );
     });
 

--- a/test/base/LoansIsCollateralSentEnoughTest.js
+++ b/test/base/LoansIsCollateralSentEnoughTest.js
@@ -25,14 +25,19 @@ contract('LoansIsCollateralSentEnoughTest', function (accounts) {
     beforeEach('Setup for each test', async () => {
         lendingPoolInstance = await LendingPool.new();
         oracleInstance = await Mock.new();
-        instance = await Loans.new(
-            oracleInstance.address,
-            lendingPoolInstance.address,
-        );
-        const zToken = await Mock.new();
-        lendingToken = await Mock.new();
         const lenders = await Mock.new();
         const settings = await Mock.new();
+
+        const zToken = await Mock.new();
+        instance = await Loans.new();
+        await instance.initialize(
+            oracleInstance.address,
+            lendingPoolInstance.address,
+            settings.address,
+        );
+        
+        lendingToken = await Mock.new();
+        
         await lendingPoolInstance.initialize(
             zToken.address,
             lendingToken.address,

--- a/test/base/LoansTakeOutLoanTest.js
+++ b/test/base/LoansTakeOutLoanTest.js
@@ -1,6 +1,6 @@
 // JS Libraries
 const withData = require('leche').withData;
-const { t, encode, createLoanInfo } = require('../utils/consts');
+const { t, encode, createLoanInfo, THIRTY_DAYS } = require('../utils/consts');
 const { createLoanSig } = require('../utils/hashes');
 const { loans } = require('../utils/events');
 
@@ -8,6 +8,7 @@ const { loans } = require('../utils/events');
 const Mock = artifacts.require("./mock/util/Mock.sol");
 
 // Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
 const Loans = artifacts.require("./mock/base/LoansMock.sol");
 
 contract('LoansTakeOutLoanTest', function (accounts) {
@@ -18,9 +19,12 @@ contract('LoansTakeOutLoanTest', function (accounts) {
     beforeEach('Setup for each test', async () => {
         lendingPoolInstance = await Mock.new();
         oracleInstance = await Mock.new();
-        instance = await Loans.new(
+        const settingsInstance = await Settings.new(1, 1, THIRTY_DAYS);
+        instance = await Loans.new();
+        await instance.initialize(
             oracleInstance.address,
             lendingPoolInstance.address,
+            settingsInstance.address,
         );
     });
 

--- a/test/base/SettingsConstructorTest.js
+++ b/test/base/SettingsConstructorTest.js
@@ -1,0 +1,35 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t } = require('../utils/consts');
+
+// Mock contracts
+
+// Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
+
+contract('SettingsConstructorTest', function (accounts) {
+
+    withData({
+        _1_basic: [1, 1, 1, undefined, false],
+        _2_not_required_submissionns: [0, 2, 3, 'MUST_PROVIDE_REQUIRED_SUBS', true],
+        _3_not_response_expiry_length: [2, 0, 0, 'MUST_PROVIDE_RESPONSE_EXP', true],
+    }, function(requiredSubmissions, maximumTolerance, responseExpiryLength, expectedErrorMessage, mustFail) {
+        it(t('user', 'new', 'Should (or not) be able to create a new instance.', mustFail), async function() {
+            // Setup
+
+            try {
+                // Invocation
+                const result = await Settings.new(requiredSubmissions, maximumTolerance, responseExpiryLength);
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+});

--- a/test/base/SettingsPauseLendingPoolTest.js
+++ b/test/base/SettingsPauseLendingPoolTest.js
@@ -12,7 +12,7 @@ contract('SettingsPauseLendingPoolTest', function (accounts) {
     let instance;
     
     beforeEach('Setup for each test', async () => {
-        instance = await Settings.new(1, 1);
+        instance = await Settings.new(1, 1, 1);
     });
 
     withData({

--- a/test/base/SettingsPauseLendingPoolTest.js
+++ b/test/base/SettingsPauseLendingPoolTest.js
@@ -1,0 +1,73 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t, NULL_ADDRESS } = require('../utils/consts');
+const { settings } = require('../utils/events');
+
+// Mock contracts
+
+// Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
+
+contract('SettingsPauseLendingPoolTest', function (accounts) {
+    let instance;
+    
+    beforeEach('Setup for each test', async () => {
+        instance = await Settings.new(1, 1);
+    });
+
+    withData({
+        _1_basic: [0, 1, undefined, false],
+        _2_notOwner: [2, 3, 'Ownable: caller is not the owner', true],
+        _3_emptyLendingPool: [0, -1, 'LENDING_POOL_IS_REQUIRED', true],
+    }, function(senderIndex, lendingPoolIndex, expectedErrorMessage, mustFail) {
+        it(t('user', 'pauseLendingPool', 'Should (or not) be able to pause a lending pool.', mustFail), async function() {
+            // Setup
+            const lendingPool = lendingPoolIndex === -1 ? NULL_ADDRESS : accounts[lendingPoolIndex];
+            const sender = accounts[senderIndex];
+
+            try {
+                // Invocation
+                const result = await instance.pauseLendingPool(lendingPool, { from: sender });
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+
+                const isLendingPoolPaused = await instance.lendingPoolPaused(lendingPool);
+                assert(isLendingPoolPaused, 'Lending pool should be paused.');
+
+                settings
+                    .lendingPoolPaused(result)
+                    .emitted(sender, lendingPool);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+
+    withData({
+        _1_basic: [0, 1],
+    }, function(senderIndex, lendingPoolIndex) {
+        it(t('user', 'pauseLendingPool', 'Should NOT be able to pause a lending pool twice.', true), async function() {
+            // Setup
+            const lendingPool = accounts[lendingPoolIndex];
+            const sender = accounts[senderIndex];
+            await instance.pauseLendingPool(lendingPool, { from: sender });
+
+            try {
+                // Invocation
+                await instance.pauseLendingPool(lendingPool, { from: sender });
+                
+                // Assertions
+                fail('It should have failed because data is invalid.');
+            } catch (error) {
+                // Assertions
+                assert(error);
+                assert.equal(error.reason, 'LENDING_POOL_ALREADY_PAUSED');
+            }
+        });
+    });
+});

--- a/test/base/SettingsPauseLendingPoolTest.js
+++ b/test/base/SettingsPauseLendingPoolTest.js
@@ -17,7 +17,7 @@ contract('SettingsPauseLendingPoolTest', function (accounts) {
 
     withData({
         _1_basic: [0, 1, undefined, false],
-        _2_notOwner: [2, 3, 'Ownable: caller is not the owner', true],
+        _2_notOwner: [2, 3, 'PauserRole: caller does not have the Pauser role', true],
         _3_emptyLendingPool: [0, -1, 'LENDING_POOL_IS_REQUIRED', true],
     }, function(senderIndex, lendingPoolIndex, expectedErrorMessage, mustFail) {
         it(t('user', 'pauseLendingPool', 'Should (or not) be able to pause a lending pool.', mustFail), async function() {

--- a/test/base/SettingsSetSettingTest.js
+++ b/test/base/SettingsSetSettingTest.js
@@ -1,0 +1,113 @@
+// JS Libraries
+const withData = require('leche').withData;
+const {
+    t,
+    REQUIRED_SUBMISSIONS,
+    RESPONSE_EXPIRY_LENGTH,
+    MAXIMUM_TOLERANCE,
+    toBytes32,
+} = require('../utils/consts');
+const { settings } = require('../utils/events');
+
+// Mock contracts
+
+// Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
+
+contract('SettingsSetSettingTest', function (accounts) {
+    let instance;
+    
+    beforeEach('Setup for each test', async () => {
+        instance = await Settings.new(1, 1, 1);
+    });
+
+    withData({
+        _1_basic: [0, 2, undefined, false],
+        _2_zero: [0, 0, 'MUST_PROVIDE_REQUIRED_SUBS', true],
+        _3_new_value_required: [0, 1, 'NEW_VALUE_REQUIRED', true],
+    }, function(senderIndex, newValue, expectedErrorMessage, mustFail) {
+        it(t('user', 'setRequiredSubmissions', 'Should (or not) be able to set a new required submissions value.', mustFail), async function() {
+            // Setup
+            const sender = accounts[senderIndex];
+            const oldValue = await instance.requiredSubmissions();
+
+            try {
+                // Invocation
+                const result = await instance.setRequiredSubmissions(newValue, { from: sender });
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+
+                settings
+                    .settingUpdated(result)
+                    .emitted(toBytes32(web3, REQUIRED_SUBMISSIONS), sender, oldValue, newValue);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+
+    withData({
+        _1_basic: [0, 2, undefined, false],
+        _2_zero: [0, 0, undefined, false],
+        _3_new_value_required: [0, 1, 'NEW_VALUE_REQUIRED', true],
+    }, function(senderIndex, newValue, expectedErrorMessage, mustFail) {
+        it(t('user', 'setMaximumTolerance', 'Should (or not) be able to set a new maximum tolerance value.', mustFail), async function() {
+            // Setup
+            const sender = accounts[senderIndex];
+            const oldValue = await instance.maximumTolerance();
+
+            try {
+                // Invocation
+                const result = await instance.setMaximumTolerance(newValue, { from: sender });
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+
+                settings
+                    .settingUpdated(result)
+                    .emitted(toBytes32(web3, MAXIMUM_TOLERANCE), sender, oldValue, newValue);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+
+    withData({
+        _1_basic: [0, 2, undefined, false],
+        _2_zero: [0, 0, 'MUST_PROVIDE_RESPONSE_EXP', true],
+        _3_new_value_required: [0, 1, 'NEW_VALUE_REQUIRED', true],
+    }, function(senderIndex, newValue, expectedErrorMessage, mustFail) {
+        it(t('user', 'setResponseExpiryLength', 'Should (or not) be able to set a new response expiry length value.', mustFail), async function() {
+            // Setup
+            const sender = accounts[senderIndex];
+            const oldValue = await instance.responseExpiryLength();
+
+            try {
+                // Invocation
+                const result = await instance.setResponseExpiryLength(newValue, { from: sender });
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+
+                settings
+                    .settingUpdated(result)
+                    .emitted(toBytes32(web3, RESPONSE_EXPIRY_LENGTH), sender, oldValue, newValue);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+});

--- a/test/base/SettingsUnpauseLendingPoolTest.js
+++ b/test/base/SettingsUnpauseLendingPoolTest.js
@@ -18,7 +18,7 @@ contract('SettingsUnpauseLendingPoolTest', function (accounts) {
 
     withData({
         _1_basic: [0, 1, undefined, false],
-        _2_notOwner: [2, 3, 'Ownable: caller is not the owner', true],
+        _2_notOwner: [2, 3, 'PauserRole: caller does not have the Pauser role', true],
         _3_emptyLendingPool: [0, -1, 'LENDING_POOL_IS_REQUIRED', true],
     }, function(senderIndex, lendingPoolIndex, expectedErrorMessage, mustFail) {
         it(t('user', 'unpauseLendingPool', 'Should (or not) be able to pause a lending pool.', mustFail), async function() {

--- a/test/base/SettingsUnpauseLendingPoolTest.js
+++ b/test/base/SettingsUnpauseLendingPoolTest.js
@@ -13,7 +13,7 @@ contract('SettingsUnpauseLendingPoolTest', function (accounts) {
     let instance;
     
     beforeEach('Setup for each test', async () => {
-        instance = await Settings.new(1, 1);
+        instance = await Settings.new(1, 1, 1);
     });
 
     withData({

--- a/test/base/SettingsUnpauseLendingPoolTest.js
+++ b/test/base/SettingsUnpauseLendingPoolTest.js
@@ -1,0 +1,78 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t, NULL_ADDRESS } = require('../utils/consts');
+const { settings } = require('../utils/events');
+
+// Mock contracts
+
+// Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
+
+contract('SettingsUnpauseLendingPoolTest', function (accounts) {
+    const owner = accounts[0];
+    let instance;
+    
+    beforeEach('Setup for each test', async () => {
+        instance = await Settings.new(1, 1);
+    });
+
+    withData({
+        _1_basic: [0, 1, undefined, false],
+        _2_notOwner: [2, 3, 'Ownable: caller is not the owner', true],
+        _3_emptyLendingPool: [0, -1, 'LENDING_POOL_IS_REQUIRED', true],
+    }, function(senderIndex, lendingPoolIndex, expectedErrorMessage, mustFail) {
+        it(t('user', 'unpauseLendingPool', 'Should (or not) be able to pause a lending pool.', mustFail), async function() {
+            // Setup
+            const lendingPool = lendingPoolIndex === -1 ? NULL_ADDRESS : accounts[lendingPoolIndex];
+            const sender = accounts[senderIndex];
+            if(lendingPool !== NULL_ADDRESS) {
+                await instance.pauseLendingPool(lendingPool, { from: owner });
+            }
+
+            try {
+                // Invocation
+                const result = await instance.unpauseLendingPool(lendingPool, { from: sender });
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+
+                const isLendingPoolPaused = await instance.lendingPoolPaused(lendingPool);
+                assert(!isLendingPoolPaused, 'Lending pool should be unpaused.');
+
+                settings
+                    .lendingPoolUnpaused(result)
+                    .emitted(sender, lendingPool);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+
+    withData({
+        _1_notPausedTwice: [0, 1],
+    }, function(senderIndex, lendingPoolIndex) {
+        it(t('user', 'unpauseLendingPool', 'Should NOT be able to unpause a lending pool twice.', true), async function() {
+            // Setup
+            const lendingPool = accounts[lendingPoolIndex];
+            const sender = accounts[senderIndex];
+            await instance.pauseLendingPool(lendingPool, { from: sender });
+            await instance.unpauseLendingPool(lendingPool, { from: sender });
+
+            try {
+                // Invocation
+                await instance.unpauseLendingPool(lendingPool, { from: sender });
+                
+                // Assertions
+                fail('It should have failed because data is invalid.');
+            } catch (error) {
+                // Assertions
+                assert(error);
+                assert.equal(error.reason, 'LENDING_POOL_IS_NOT_PAUSED');
+            }
+        });
+    });
+});

--- a/test/providers/chainlink/ChainlinkPairAggregatorGetLatestRoundTest.js
+++ b/test/providers/chainlink/ChainlinkPairAggregatorGetLatestRoundTest.js
@@ -1,0 +1,46 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t } = require('../../utils/consts');
+const AggregatorInterfaceEncoder = require('../../utils/encoders/AggregatorInterfaceEncoder');
+
+// Mock contracts
+const ChainlinkAggregatorMock = artifacts.require("./mock/util/Mock.sol");
+
+// Smart contracts
+const ChainlinkPairAggregator = artifacts.require("./providers/chainlink/ChainlinkPairAggregator.sol");
+
+contract('ChainlinkPairAggregatorGetLatestRoundTest', function (accounts) {
+    const aggregatorInterfaceEncoder = new AggregatorInterfaceEncoder(web3);
+    let chainlinkAggregator;
+    let instance;
+
+    beforeEach('Setup for each test', async () => {
+        chainlinkAggregator = await ChainlinkAggregatorMock.new();
+        assert(chainlinkAggregator);
+        assert(chainlinkAggregator.address);
+
+        instance = await ChainlinkPairAggregator.new(chainlinkAggregator.address);
+        assert(instance);
+        assert(instance.address);
+    });
+
+    withData({
+        _1_basic: [210000]
+    }, function(
+        latestRoundResponse
+    ) {    
+        it(t('user', 'getLatestRound', 'Should able to get the last round.', false), async function() {
+            // Setups
+            await chainlinkAggregator.givenMethodReturnUint(
+                aggregatorInterfaceEncoder.encodeLatestRound(),
+                latestRoundResponse.toString()
+            );
+
+            // Invocation
+            const result = await instance.getLatestRound();
+
+            // Assertions
+            assert.equal(result.toString(), latestRoundResponse.toString());
+        });
+    });
+});

--- a/test/util/AddressLibTest.js
+++ b/test/util/AddressLibTest.js
@@ -1,0 +1,185 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t, NULL_ADDRESS } = require('../utils/consts');
+
+// Smart contracts
+const AddressLibMock = artifacts.require("./mock/util/AddressLibMock.sol");
+
+contract('AddressLibTest', function (accounts) {
+    let instance;
+    
+    beforeEach('Setup for each test', async () => {
+        instance = await AddressLibMock.new();
+    });
+
+    withData({
+        _1_basic: [0, false],
+        _2_empty: [-1, true]
+    }, function(addressIndex, expectedResult) {
+        it(t('user', 'isEmpty', 'Should be able to test whether address is empty or not.', false), async function() {
+            // Setup
+            const address = addressIndex === -1 ? NULL_ADDRESS : accounts[addressIndex];
+
+            // Invocation
+            const result = await instance.isEmpty(address);
+            
+            // Assertions
+            assert.equal(result.toString(), expectedResult.toString());
+        });
+    });
+
+    withData({
+        _1_basic: [0, true],
+        _2_empty: [-1, false]
+    }, function(addressIndex, expectedResult) {
+        it(t('user', 'isNotEmpty', 'Should be able to test whether address is empty or not.', false), async function() {
+            // Setup
+            const address = addressIndex === -1 ? NULL_ADDRESS : accounts[addressIndex];
+
+            // Invocation
+            const result = await instance.isNotEmpty(address);
+            
+            // Assertions
+            assert.equal(result.toString(), expectedResult.toString());
+        });
+    });
+
+    withData({
+        _1_basic: [0, undefined, false],
+        _2_empty: [-1, 'ADDRESS_MUST_BE_PROVIDED', true]
+    }, function(addressIndex, expectedErrorMessage, mustFail) {
+        it(t('user', 'requireNotEmpty', 'Should be able to require address is not empty.', false), async function() {
+            // Setup
+            const address = addressIndex === -1 ? NULL_ADDRESS : accounts[addressIndex];
+
+            try {
+                // Invocation
+                const result = await instance.requireNotEmpty(address);
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert(error.message.endsWith(expectedErrorMessage));
+            }
+        });
+    });
+
+    withData({
+        _1_basic: [-1, undefined, false],
+        _2_empty: [0, 'ADDRESS_MUST_BE_EMPTY', true]
+    }, function(addressIndex, expectedErrorMessage, mustFail) {
+        it(t('user', 'requireEmpty', 'Should be able to require address is not empty.', false), async function() {
+            // Setup
+            const address = addressIndex === -1 ? NULL_ADDRESS : accounts[addressIndex];
+
+            try {
+                // Invocation
+                const result = await instance.requireEmpty(address);
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert(error.message.endsWith(expectedErrorMessage));
+            }
+        });
+    });
+
+    withData({
+        _1_basic: [0, 1, false],
+        _2_equalEmpty: [-1, -1, true],
+        _3_emptyAndNotEmpty: [-1, 1, false],
+        _4_equal: [1, 1, true]
+    }, function(leftAddressIndex, rightAddressIndex, expectedResult) {
+        it(t('user', 'isEqualTo', 'Should be able to test whether two addresses are equal or not.', false), async function() {
+            // Setup
+            const leftAddress = leftAddressIndex === -1 ? NULL_ADDRESS : accounts[leftAddressIndex];
+            const rightAddress = rightAddressIndex === -1 ? NULL_ADDRESS : accounts[rightAddressIndex];
+
+            // Invocation
+            const result = await instance.isEqualTo(leftAddress, rightAddress);
+            
+            // Assertions
+            assert.equal(result.toString(), expectedResult.toString());
+        });
+    });
+
+    withData({
+        _1_basic: [0, 1, true],
+        _2_equalEmpty: [-1, -1, false],
+        _3_emptyAndNotEmpty: [-1, 1, true],
+        _4_equal: [1, 1, false]
+    }, function(leftAddressIndex, rightAddressIndex, expectedResult) {
+        it(t('user', 'isNotEqualTo', 'Should be able to test whether two addresses are equal or not.', false), async function() {
+            // Setup
+            const leftAddress = leftAddressIndex === -1 ? NULL_ADDRESS : accounts[leftAddressIndex];
+            const rightAddress = rightAddressIndex === -1 ? NULL_ADDRESS : accounts[rightAddressIndex];
+
+            // Invocation
+            const result = await instance.isNotEqualTo(leftAddress, rightAddress);
+            
+            // Assertions
+            assert.equal(result.toString(), expectedResult.toString());
+        });
+    });
+
+    withData({
+        _1_basic: [2, 2, undefined, false],
+        _2_emptyEqual: [-1, -1, undefined, false],
+        _3_notEqual: [-1, 1, 'ADDRESSES_MUST_BE_EQUAL', true],
+    }, function(leftAddressIndex, rightAddressIndex, expectedErrorMessage, mustFail) {
+        it(t('user', 'requireEqualTo', 'Should be able to require address is not empty.', false), async function() {
+            // Setup
+            const leftAddress = leftAddressIndex === -1 ? NULL_ADDRESS : accounts[leftAddressIndex];
+            const rightAddress = rightAddressIndex === -1 ? NULL_ADDRESS : accounts[rightAddressIndex];
+
+            try {
+                // Invocation
+                const result = await instance.requireEqualTo(leftAddress, rightAddress);
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert(error.message.endsWith(expectedErrorMessage));
+            }
+        });
+    });
+
+    withData({
+        _1_basic: [1, 2, undefined, false],
+        _2_basic: [-1, 2, undefined, false],
+        _3_emptyEqual: [-1, -1, 'ADDRESSES_MUST_NOT_BE_EQUAL', true],
+        _4_notEmptyEqual: [1, 1, 'ADDRESSES_MUST_NOT_BE_EQUAL', true],
+    }, function(leftAddressIndex, rightAddressIndex, expectedErrorMessage, mustFail) {
+        it(t('user', 'requireNotEqualTo', 'Should be able to require address is not empty.', false), async function() {
+            // Setup
+            const leftAddress = leftAddressIndex === -1 ? NULL_ADDRESS : accounts[leftAddressIndex];
+            const rightAddress = rightAddressIndex === -1 ? NULL_ADDRESS : accounts[rightAddressIndex];
+
+            try {
+                // Invocation
+                const result = await instance.requireNotEqualTo(leftAddress, rightAddress);
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert(error.message.endsWith(expectedErrorMessage));
+            }
+        });
+    });
+});

--- a/test/utils/consts.js
+++ b/test/utils/consts.js
@@ -1,5 +1,8 @@
 const { BigNumber } = require( 'bignumber.js');
 
+const REQUIRED_SUBMISSIONS = 'RequiredSubmissions';
+const MAXIMUM_TOLERANCE = 'MaximumTolerance';
+const RESPONSE_EXPIRY_LENGTH = 'ResponseExpiryLength';
 const DEFAULT_DECIMALS = 18;
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
 const NULL_BYTES = '0x0000000000000000000000000000000000000000000000000000000000000000'
@@ -20,6 +23,9 @@ module.exports = {
     ONE_HOUR,
     ONE_DAY,
     THIRTY_DAYS,
+    REQUIRED_SUBMISSIONS,
+    MAXIMUM_TOLERANCE,
+    RESPONSE_EXPIRY_LENGTH,
     t: function (who, func, desc, fail) {
         const failText = fail ? '\x1b[31mMustFail\x1b[0m .' : '\x1b[0m';
         return '\x1b[32m.' + func + ' => \x1b[36m' + who + '\x1b[0m\033[01;34m : ' + desc + ' '+ failText;
@@ -75,5 +81,8 @@ module.exports = {
             signerNonce: 0,
             takeOutLoanValue: 1,
         };
+    },
+    toBytes32: (web3, text) => {
+        return web3.utils.padRight(web3.utils.stringToHex(text), 64, '0');
     },
 }

--- a/test/utils/contracts.js
+++ b/test/utils/contracts.js
@@ -8,13 +8,14 @@ module.exports = {
             lenderData.lastAccruedInterest
         );
     },
-    initContracts: async (lendingPool, zToken, consensus, dai, loans, Lenders) => {
+    initContracts: async (settings, lendingPool, zToken, consensus, dai, loans, Lenders) => {
         const lenders = await Lenders.new(zToken.address, lendingPool.address, consensus.address);
         await lendingPool.initialize(
             zToken.address,
             dai.address,
             lenders.address,
             loans.address,
+            settings.address,
         );
         return lenders;
     },

--- a/test/utils/contracts.js
+++ b/test/utils/contracts.js
@@ -8,11 +8,17 @@ module.exports = {
             lenderData.lastAccruedInterest
         );
     },
-    initContracts: async (settings, lendingPool, zToken, consensus, dai, loans, Lenders) => {
-        const lenders = await Lenders.new(zToken.address, lendingPool.address, consensus.address);
+    initContracts: async (settings, lendingPool, zToken, consensus, lendingToken, loans, Lenders) => {
+        const lenders = await Lenders.new();
+        await lenders.initialize(
+            zToken.address,
+            lendingPool.address,
+            consensus.address,
+            settings.address,
+        );
         await lendingPool.initialize(
             zToken.address,
-            dai.address,
+            lendingToken.address,
             lenders.address,
             loans.address,
             settings.address,

--- a/test/utils/events.js
+++ b/test/utils/events.js
@@ -100,6 +100,17 @@ module.exports = {
                 notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
             };
         },
+        interestWithdrawn: tx => {
+            const name = 'InterestWithdrawn';
+            return {
+                name: name,
+                emitted: (lender, amount) => emitted(tx, name, ev => {
+                    assert.equal(ev.lender, lender);
+                    assert.equal(ev.amount.toString(), amount.toString());
+                }),
+                notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
+            };
+        },
     },
     loans: {
         loanCreated: tx => {

--- a/test/utils/events.js
+++ b/test/utils/events.js
@@ -148,5 +148,28 @@ module.exports = {
             notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
         };
     },
-  },
+    settings: {
+        lendingPoolPaused: tx => {
+            const name = 'LendingPoolPaused';
+            return {
+                name: name,
+                emitted: (account, lendingPoolAddress) => emitted(tx, name, ev => {
+                    assert.equal(ev.account, account);
+                    assert.equal(ev.lendingPoolAddress, lendingPoolAddress);
+                }),
+                notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
+            };
+        },
+        lendingPoolUnpaused: tx => {
+            const name = 'LendingPoolUnpaused';
+            return {
+                name: name,
+                emitted: (account, lendingPoolAddress) => emitted(tx, name, ev => {
+                    assert.equal(ev.account, account);
+                    assert.equal(ev.lendingPoolAddress, lendingPoolAddress);
+                }),
+                notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
+            };
+        },
+    }
 };

--- a/test/utils/events.js
+++ b/test/utils/events.js
@@ -172,5 +172,19 @@ module.exports = {
                 notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
             };
         },
+        settingUpdated: tx => {
+            const name = 'SettingUpdated';
+            return {
+                name: name,
+                emitted: (settingName, sender, oldValue, newValue) => emitted(tx, name, ev => {
+                    assert.equal(ev.settingName.toString(), settingName.toString());
+                    assert.equal(ev.sender, sender);
+                    assert.equal(ev.oldValue.toString(), oldValue.toString());
+                    assert.equal(ev.newValue, newValue);
+
+                }),
+                notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
+            };
+        },
     }
 };

--- a/test/utils/events.js
+++ b/test/utils/events.js
@@ -119,34 +119,35 @@ module.exports = {
         },
     },
     interestConsensus: {
-      interestSubmitted: tx => {
-          const name = 'InterestSubmitted';
-          return {
-              name: name,
-              emitted: (signer, lender, blockNumber, interest) => truffleAssert.eventEmitted(tx, name, ev => {
-                  return (
-                      ev.signer == signer && 
-                      ev.lender == lender &&
-                      ev.blockNumber.toString() == blockNumber.toString() &&
-                      ev.interest.toString() == interest.toString()
-                  )
-              }),
-              notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
-          };
-      },
-      interestAccepted: tx => {
-        const name = 'InterestAccepted';
-        return {
-            name: name,
-            emitted: (lender, blockNumber, interest) => truffleAssert.eventEmitted(tx, name, ev => {
-                return (
-                    ev.lender == lender && 
-                    ev.blockNumber.toString() == blockNumber.toString() &&
-                    ev.interest.toString() == interest.toString()
-                )
-            }),
-            notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
-        };
+        interestSubmitted: tx => {
+            const name = 'InterestSubmitted';
+            return {
+                name: name,
+                emitted: (signer, lender, blockNumber, interest) => truffleAssert.eventEmitted(tx, name, ev => {
+                    return (
+                        ev.signer == signer && 
+                        ev.lender == lender &&
+                        ev.blockNumber.toString() == blockNumber.toString() &&
+                        ev.interest.toString() == interest.toString()
+                    )
+                }),
+                notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
+            };
+        },
+        interestAccepted: tx => {
+            const name = 'InterestAccepted';
+            return {
+                name: name,
+                emitted: (lender, blockNumber, interest) => truffleAssert.eventEmitted(tx, name, ev => {
+                    return (
+                        ev.lender == lender && 
+                        ev.blockNumber.toString() == blockNumber.toString() &&
+                        ev.interest.toString() == interest.toString()
+                    )
+                }),
+                notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
+            };
+        },
     },
     settings: {
         lendingPoolPaused: tx => {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -45,6 +45,8 @@ module.exports = {
 				'InterestConsensusMock',
 				'NumbersListMock',
 				'BaseMock',
+				'ConsensusMock',
+				'InterestConsensusModifiersMock',
 			]
 		},
 	},

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -44,6 +44,7 @@ module.exports = {
 				'InitializableModifiersMock',
 				'InterestConsensusMock',
 				'NumbersListMock',
+				'BaseMock',
 			]
 		},
 	},

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -64,7 +64,7 @@ module.exports = {
 			host: '127.0.0.1',
 			port: 8545,
 			network_id: '*',
-			gas: 0x90F560,
+			gas: gasKeyValue,
 			gasPrice: 0x01,
 		},
 		ropsten: {


### PR DESCRIPTION
It includes:

- A Settings contract to allow us:
     - To configure any required value in the platform.
     - To pause the platform.
     - To pause a lending pool.
- A Base contract which extends the ReentrancyGuard contract, and has the Settings contract.
- Changes in migration script.
- New unit tests to increase code coverage (almost 100%).

So,

Any contract can extend Base and get access to:
- Any setting defined in the Settings contract.
- Checking whether the platform or a lending pool is paused or not.

![image](https://user-images.githubusercontent.com/5948309/81215367-9defab00-8faf-11ea-9ea3-47b60e0a7471.png)


![image](https://user-images.githubusercontent.com/5948309/81079334-d2873800-8ec5-11ea-9e74-339e1cbce98a.png)

